### PR TITLE
docs: add Homebrew install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ brew tap 1mb-dev/tap
 brew install natcheck
 ```
 
-**Go install (any platform):**
+**Go install (any platform with Go 1.25+):**
 
 ```bash
 go install github.com/1mb-dev/natcheck/cmd/natcheck@latest
 ```
+
+Then run:
 
 ```bash
 natcheck

--- a/README.md
+++ b/README.md
@@ -14,9 +14,20 @@ Built on [`pion/stun`](https://github.com/pion/stun). Pure Go, single static bin
 
 ## Quick start
 
+**Homebrew (recommended on macOS):**
+
+```bash
+brew tap 1mb-dev/tap
+brew install natcheck
+```
+
+**Go install (any platform):**
+
 ```bash
 go install github.com/1mb-dev/natcheck/cmd/natcheck@latest
+```
 
+```bash
 natcheck
 ```
 


### PR DESCRIPTION
Adds a Homebrew install block above `go install` in Quick start, pointing at the new [`1mb-dev/homebrew-tap`](https://github.com/1mb-dev/homebrew-tap).

Source-build formula pinned to v0.1.1. Verified end-to-end: `brew tap 1mb-dev/tap && brew install natcheck` builds in ~5s and `natcheck --version` reports `0.1.1`.

No code changes — README only.