### PR TITLE
feat(stunserver): add internal/stunserver package foundation

### DIFF
--- a/internal/probe/stun_test.go
+++ b/internal/probe/stun_test.go
@@ -3,9 +3,11 @@ package probe
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
+	"github.com/1mb-dev/natcheck/internal/stunserver"
 	"github.com/pion/stun/v3"
 )
 
@@ -87,16 +89,13 @@ func (f *fakeSTUN) serve() {
 func buildResponse(behavior fakeBehavior, req *stun.Message, udp *net.UDPAddr) []byte {
 	switch behavior {
 	case behaviorNormal:
-		resp, err := stun.Build(
-			stun.NewTransactionIDSetter(req.TransactionID),
-			stun.BindingSuccess,
-			&stun.XORMappedAddress{IP: udp.IP, Port: udp.Port},
-		)
-		if err != nil {
-			return nil
-		}
-		return resp.Raw
+		addr, _ := netip.AddrFromSlice(udp.IP)
+		src := netip.AddrPortFrom(addr.Unmap(), uint16(udp.Port))
+		return stunserver.New(stunserver.Options{}).Handle(req.Raw, src)
 
+	// The branches below intentionally produce non-conforming or absent
+	// responses. They exist to validate probe-client robustness against
+	// misbehaving servers, which stunserver.Handle by design never produces.
 	case behaviorWrongTxID:
 		var wrong [stun.TransactionIDSize]byte
 		for i := range wrong {

--- a/internal/stunserver/server.go
+++ b/internal/stunserver/server.go
@@ -1,0 +1,111 @@
+// Package stunserver implements a stateless STUN responder for natcheck.
+//
+// The package exposes two consumption modes built on the same Handle function:
+// pure byte-in/byte-out for in-process tests, and a PacketConn dispatch loop
+// for use as a long-running responder. Currently supports plain BindingRequest;
+// CHANGE-REQUEST handling planned per docs/design.md v0.2 addendum.
+package stunserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/pion/stun/v3"
+)
+
+// Options configures a Server. Empty for the plain-Binding responder;
+// CHANGE-REQUEST-related fields (AltIP, AltPort) join when CHANGE-REQUEST
+// support lands.
+type Options struct{}
+
+// Server is a stateless STUN responder. Construct via New. Handle is pure and
+// safe for concurrent use across goroutines. Serve owns its PacketConn — do
+// not call Serve concurrently with the same conn.
+type Server struct{}
+
+// New returns a Server configured with opts.
+func New(opts Options) *Server {
+	_ = opts
+	return &Server{}
+}
+
+// Handle processes a single STUN request and returns the wire bytes of the
+// response, or nil to indicate no reply (drop). The src argument is the
+// observed source endpoint and is echoed in XOR-MAPPED-ADDRESS.
+//
+// Handle never panics. Malformed input, unsupported message types, and any
+// build failure are silently dropped (return nil) per the diagnostic-responder
+// posture. Response size is comparable to request size; no meaningful
+// amplification factor.
+func (s *Server) Handle(req []byte, src netip.AddrPort) []byte {
+	msg := &stun.Message{Raw: req}
+	if err := msg.Decode(); err != nil {
+		return nil
+	}
+	if msg.Type != stun.BindingRequest {
+		return nil
+	}
+	resp, err := stun.Build(
+		stun.NewTransactionIDSetter(msg.TransactionID),
+		stun.BindingSuccess,
+		&stun.XORMappedAddress{IP: src.Addr().AsSlice(), Port: int(src.Port())},
+	)
+	if err != nil {
+		return nil
+	}
+	return resp.Raw
+}
+
+// Serve runs a read-decode-Handle-write loop on conn until ctx is cancelled or
+// conn returns net.ErrClosed. On ctx cancellation, Serve forces any in-flight
+// ReadFrom to return immediately by setting a deadline in the past (matching
+// the cancellation idiom in internal/probe/stun.go).
+//
+// Per-packet decode failures and non-UDP source addresses are swallowed; the
+// loop continues. WriteTo errors (e.g., destination unreachable) are silently
+// dropped — diagnostic-responder posture, not a delivery-guaranteed service.
+//
+// Returns ctx.Err() on cancellation or the underlying conn error (typically
+// net.ErrClosed) on shutdown.
+func (s *Server) Serve(ctx context.Context, conn net.PacketConn) error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetReadDeadline(time.Unix(1, 0))
+		case <-done:
+		}
+	}()
+
+	for {
+		buf := make([]byte, 1500)
+		n, from, err := conn.ReadFrom(buf)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return err
+			}
+			continue
+		}
+		udp, ok := from.(*net.UDPAddr)
+		if !ok {
+			continue
+		}
+		addr, ok := netip.AddrFromSlice(udp.IP)
+		if !ok {
+			continue
+		}
+		src := netip.AddrPortFrom(addr.Unmap(), uint16(udp.Port))
+		resp := s.Handle(buf[:n], src)
+		if resp == nil {
+			continue
+		}
+		_, _ = conn.WriteTo(resp, from)
+	}
+}

--- a/internal/stunserver/server_test.go
+++ b/internal/stunserver/server_test.go
@@ -1,0 +1,216 @@
+package stunserver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/1mb-dev/natcheck/internal/probe"
+	"github.com/pion/stun/v3"
+)
+
+func mustEncodeBindingRequest(t *testing.T) *stun.Message {
+	t.Helper()
+	m, err := stun.Build(stun.TransactionID, stun.BindingRequest)
+	if err != nil {
+		t.Fatalf("build binding request: %v", err)
+	}
+	m.Encode()
+	return m
+}
+
+func TestHandle_BindingRequestIPv4(t *testing.T) {
+	s := New(Options{})
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("127.0.0.1:51234")
+
+	out := s.Handle(req.Raw, src)
+	if out == nil {
+		t.Fatal("expected response, got nil")
+	}
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Type != stun.BindingSuccess {
+		t.Fatalf("type = %v, want BindingSuccess", resp.Type)
+	}
+	if resp.TransactionID != req.TransactionID {
+		t.Fatal("transaction ID mismatch")
+	}
+	var xor stun.XORMappedAddress
+	if err := xor.GetFrom(resp); err != nil {
+		t.Fatalf("XOR-MAPPED-ADDRESS: %v", err)
+	}
+	got, _ := netip.AddrFromSlice(xor.IP)
+	gotAP := netip.AddrPortFrom(got.Unmap(), uint16(xor.Port))
+	if gotAP != src {
+		t.Fatalf("mapped = %v, want %v", gotAP, src)
+	}
+}
+
+func TestHandle_BindingRequestIPv6(t *testing.T) {
+	s := New(Options{})
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("[::1]:51234")
+
+	out := s.Handle(req.Raw, src)
+	if out == nil {
+		t.Fatal("expected response, got nil")
+	}
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	var xor stun.XORMappedAddress
+	if err := xor.GetFrom(resp); err != nil {
+		t.Fatalf("XOR-MAPPED-ADDRESS: %v", err)
+	}
+	got, ok := netip.AddrFromSlice(xor.IP)
+	if !ok {
+		t.Fatalf("invalid mapped IP %v", xor.IP)
+	}
+	if !got.Is6() {
+		t.Fatalf("mapped IP = %v, want IPv6", got)
+	}
+	gotAP := netip.AddrPortFrom(got, uint16(xor.Port))
+	if gotAP != src {
+		t.Fatalf("mapped = %v, want %v", gotAP, src)
+	}
+}
+
+func TestHandle_NonBindingType(t *testing.T) {
+	s := New(Options{})
+	m, err := stun.Build(stun.TransactionID, stun.BindingError)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m.Encode()
+
+	if out := s.Handle(m.Raw, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for BindingError, got %d bytes", len(out))
+	}
+}
+
+func TestHandle_AllocateRequest(t *testing.T) {
+	s := New(Options{})
+	// AllocateRequest is a TURN method, not a STUN Binding method.
+	allocate := stun.NewType(stun.MethodAllocate, stun.ClassRequest)
+	m, err := stun.Build(stun.TransactionID, allocate)
+	if err != nil {
+		t.Fatalf("build allocate: %v", err)
+	}
+	m.Encode()
+
+	if out := s.Handle(m.Raw, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for AllocateRequest, got %d bytes", len(out))
+	}
+}
+
+func TestHandle_TooShort(t *testing.T) {
+	s := New(Options{})
+	if out := s.Handle([]byte{0xff, 0xff}, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for too-short input, got %d bytes", len(out))
+	}
+}
+
+func TestHandle_Empty(t *testing.T) {
+	s := New(Options{})
+	if out := s.Handle(nil, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for nil input, got %d bytes", len(out))
+	}
+	if out := s.Handle([]byte{}, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for empty input, got %d bytes", len(out))
+	}
+}
+
+func TestHandle_Garbled(t *testing.T) {
+	s := New(Options{})
+	garbage := make([]byte, 100)
+	for i := range garbage {
+		garbage[i] = 0xFF
+	}
+	if out := s.Handle(garbage, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
+		t.Fatalf("expected nil for garbled input, got %d bytes", len(out))
+	}
+}
+
+func TestServe_RoundTrip(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	udpAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- New(Options{}).Serve(ctx, conn) }()
+
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), time.Second)
+	defer probeCancel()
+	res := probe.NewSTUN().Probe(probeCtx, probe.Server{Host: "127.0.0.1", Port: udpAddr.Port})
+	if res.Err != nil {
+		t.Fatalf("probe: %v", res.Err)
+	}
+	if !res.Mapped.Addr().IsLoopback() {
+		t.Fatalf("mapped = %v, want loopback", res.Mapped.Addr())
+	}
+
+	cancel()
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("serve returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve did not return within 1s of cancel")
+	}
+}
+
+func TestServe_ContextCancel(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- New(Options{}).Serve(ctx, conn) }()
+
+	cancel()
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("serve returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve did not return within 1s of cancel")
+	}
+}
+
+func TestServe_ConnClosed(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx := context.Background()
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- New(Options{}).Serve(ctx, conn) }()
+	// No sleep: ReadFrom returns net.ErrClosed deterministically once we close,
+	// regardless of whether Serve has entered the read yet.
+	_ = conn.Close()
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, net.ErrClosed) {
+			t.Fatalf("serve returned %v, want net.ErrClosed", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve did not return within 1s of conn close")
+	}
+}


### PR DESCRIPTION
v0.1.2 phase 1 of 5. New `internal/stunserver/` package: `Handle` (pure, BindingRequest only) + `Serve` (PacketConn dispatch). Cancellation via the `SetDeadline(time.Unix(1, 0))` watcher idiom from `internal/probe/stun.go`. Empty `Options{}` placeholder; CHANGE-REQUEST fields land in phase 2.

`internal/probe/stun_test.go` `behaviorNormal` branch delegates to `stunserver.Handle`. Adversarial branches stay hand-rolled — they test probe-client robustness against malformed responses.

No CLI / JSON / exit-code / CHANGELOG impact.

## Verification

- `go vet`, `gofmt`, `go mod tidy -diff` — clean
- `make test` (race, 60s, 5 packages) — green
- `make lint` — 0 issues
- `go test -race -count=3 ./internal/stunserver/ ./internal/probe/` — no flake
- `internal/stunserver/` coverage: 86.1% (two defensive guards in `Serve` unreachable with `net.ListenPacket`)
- `internal/probe/` test count unchanged (9)