### PR TITLE
feat(stunserver): add OTHER-ADDRESS support and ParseChangeRequest

### DIFF
--- a/internal/stunserver/server.go
+++ b/internal/stunserver/server.go
@@ -2,12 +2,14 @@
 //
 // The package exposes two consumption modes built on the same Handle function:
 // pure byte-in/byte-out for in-process tests, and a PacketConn dispatch loop
-// for use as a long-running responder. Currently supports plain BindingRequest;
-// CHANGE-REQUEST handling planned per docs/design.md v0.2 addendum.
+// for use as a long-running responder. Supports BindingRequest with optional
+// OTHER-ADDRESS responses (RFC 5780 §7.4). CHANGE-REQUEST routing is a caller
+// concern — use ParseChangeRequest to extract flags from incoming requests.
 package stunserver
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"net"
 	"net/netip"
@@ -16,20 +18,24 @@ import (
 	"github.com/pion/stun/v3"
 )
 
-// Options configures a Server. Empty for the plain-Binding responder;
-// CHANGE-REQUEST-related fields (AltIP, AltPort) join when CHANGE-REQUEST
-// support lands.
-type Options struct{}
+// Options configures a Server.
+type Options struct {
+	// Other is the address of the diagonal peer in an RFC 5780 §3 four-corner
+	// topology. When set, Handle includes an OTHER-ADDRESS attribute pointing
+	// to it. Zero-value disables the attribute.
+	Other netip.AddrPort
+}
 
 // Server is a stateless STUN responder. Construct via New. Handle is pure and
 // safe for concurrent use across goroutines. Serve owns its PacketConn — do
 // not call Serve concurrently with the same conn.
-type Server struct{}
+type Server struct {
+	opts Options
+}
 
 // New returns a Server configured with opts.
 func New(opts Options) *Server {
-	_ = opts
-	return &Server{}
+	return &Server{opts: opts}
 }
 
 // Handle processes a single STUN request and returns the wire bytes of the
@@ -48,11 +54,17 @@ func (s *Server) Handle(req []byte, src netip.AddrPort) []byte {
 	if msg.Type != stun.BindingRequest {
 		return nil
 	}
-	resp, err := stun.Build(
+	srcAddr := src.Addr().Unmap()
+	setters := []stun.Setter{
 		stun.NewTransactionIDSetter(msg.TransactionID),
 		stun.BindingSuccess,
-		&stun.XORMappedAddress{IP: src.Addr().AsSlice(), Port: int(src.Port())},
-	)
+		&stun.XORMappedAddress{IP: srcAddr.AsSlice(), Port: int(src.Port())},
+	}
+	if s.opts.Other.IsValid() {
+		o := s.opts.Other.Addr().Unmap()
+		setters = append(setters, &stun.OtherAddress{IP: o.AsSlice(), Port: int(s.opts.Other.Port())})
+	}
+	resp, err := stun.Build(setters...)
 	if err != nil {
 		return nil
 	}
@@ -108,4 +120,26 @@ func (s *Server) Serve(ctx context.Context, conn net.PacketConn) error {
 		}
 		_, _ = conn.WriteTo(resp, from)
 	}
+}
+
+// ParseChangeRequest extracts CHANGE-REQUEST flags from a STUN BindingRequest.
+// Returns ok=false for messages other than BindingRequest, malformed STUN,
+// missing CHANGE-REQUEST attribute, or attribute payloads not exactly 4 bytes.
+func ParseChangeRequest(req []byte) (changeIP, changePort, ok bool) {
+	msg := &stun.Message{Raw: req}
+	if err := msg.Decode(); err != nil {
+		return false, false, false
+	}
+	if msg.Type != stun.BindingRequest {
+		return false, false, false
+	}
+	v, err := msg.Get(stun.AttrChangeRequest)
+	if err != nil || len(v) != 4 {
+		return false, false, false
+	}
+	// RFC 5780 §7.2: bit A (0x04) = change IP, bit B (0x02) = change port.
+	// Other bits MUST be zero per RFC; we extract A/B only and ignore the
+	// rest (matches phase 1's silent-drop posture for diagnostic responder).
+	flags := binary.BigEndian.Uint32(v)
+	return flags&0x04 != 0, flags&0x02 != 0, true
 }

--- a/internal/stunserver/server_test.go
+++ b/internal/stunserver/server_test.go
@@ -2,6 +2,7 @@ package stunserver
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"net"
 	"net/netip"
@@ -212,5 +213,289 @@ func TestServe_ConnClosed(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("serve did not return within 1s of conn close")
+	}
+}
+
+// --- OTHER-ADDRESS tests ---
+
+func TestHandle_OtherAddressIPv4(t *testing.T) {
+	other := netip.MustParseAddrPort("192.0.2.1:3479")
+	s := New(Options{Other: other})
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("127.0.0.1:51234")
+
+	out := s.Handle(req.Raw, src)
+	if out == nil {
+		t.Fatal("expected response, got nil")
+	}
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var oa stun.OtherAddress
+	if err := oa.GetFrom(resp); err != nil {
+		t.Fatalf("OTHER-ADDRESS missing: %v", err)
+	}
+	gotIP, _ := netip.AddrFromSlice(oa.IP)
+	gotAP := netip.AddrPortFrom(gotIP.Unmap(), uint16(oa.Port))
+	if gotAP != other {
+		t.Fatalf("OTHER-ADDRESS = %v, want %v", gotAP, other)
+	}
+}
+
+func TestHandle_OtherAddressIPv6(t *testing.T) {
+	other := netip.MustParseAddrPort("[2001:db8::1]:3479")
+	s := New(Options{Other: other})
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("[::1]:51234")
+
+	out := s.Handle(req.Raw, src)
+	if out == nil {
+		t.Fatal("expected response, got nil")
+	}
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var oa stun.OtherAddress
+	if err := oa.GetFrom(resp); err != nil {
+		t.Fatalf("OTHER-ADDRESS missing: %v", err)
+	}
+	gotIP, ok := netip.AddrFromSlice(oa.IP)
+	if !ok {
+		t.Fatalf("invalid OTHER-ADDRESS IP: %v", oa.IP)
+	}
+	if !gotIP.Is6() {
+		t.Fatalf("OTHER-ADDRESS family = %v, want IPv6", gotIP)
+	}
+	gotAP := netip.AddrPortFrom(gotIP, uint16(oa.Port))
+	if gotAP != other {
+		t.Fatalf("OTHER-ADDRESS = %v, want %v", gotAP, other)
+	}
+}
+
+func TestHandle_OtherAddressAbsent(t *testing.T) {
+	s := New(Options{}) // no Other configured
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("127.0.0.1:51234")
+
+	out := s.Handle(req.Raw, src)
+	if out == nil {
+		t.Fatal("expected response, got nil")
+	}
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var oa stun.OtherAddress
+	if err := oa.GetFrom(resp); !errors.Is(err, stun.ErrAttributeNotFound) {
+		t.Fatalf("OTHER-ADDRESS GetFrom err = %v, want ErrAttributeNotFound", err)
+	}
+	// Regression backstop: with Options{}, response carries exactly one
+	// attribute (XOR-MAPPED-ADDRESS). Future silent additions break this test.
+	if got := len(resp.Attributes); got != 1 {
+		t.Fatalf("attribute count = %d, want 1", got)
+	}
+	if resp.Attributes[0].Type != stun.AttrXORMappedAddress {
+		t.Fatalf("sole attribute type = %v, want XOR-MAPPED-ADDRESS", resp.Attributes[0].Type)
+	}
+}
+
+func TestHandle_OtherAddressUnmaps(t *testing.T) {
+	// IPv4-mapped IPv6 address must be encoded as IPv4 family in OTHER-ADDRESS.
+	mapped := netip.AddrPortFrom(netip.MustParseAddr("::ffff:192.0.2.1"), 3479)
+	s := New(Options{Other: mapped})
+	req := mustEncodeBindingRequest(t)
+	src := netip.MustParseAddrPort("127.0.0.1:51234")
+
+	out := s.Handle(req.Raw, src)
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var oa stun.OtherAddress
+	if err := oa.GetFrom(resp); err != nil {
+		t.Fatalf("OTHER-ADDRESS missing: %v", err)
+	}
+	if len(oa.IP) != 4 {
+		t.Fatalf("OTHER-ADDRESS IP length = %d, want 4 (IPv4 family)", len(oa.IP))
+	}
+	wantIP := netip.MustParseAddr("192.0.2.1")
+	gotIP, _ := netip.AddrFromSlice(oa.IP)
+	if gotIP.Unmap() != wantIP {
+		t.Fatalf("OTHER-ADDRESS IP = %v, want %v", gotIP.Unmap(), wantIP)
+	}
+}
+
+// --- ParseChangeRequest tests ---
+
+func buildBindingRequestWithChange(t *testing.T, flags uint32) *stun.Message {
+	t.Helper()
+	var v [4]byte
+	binary.BigEndian.PutUint32(v[:], flags)
+	m, err := stun.Build(stun.TransactionID, stun.BindingRequest, stun.RawAttribute{
+		Type:   stun.AttrChangeRequest,
+		Length: 4,
+		Value:  v[:],
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m.Encode()
+	return m
+}
+
+func TestParseChangeRequest_BothFlags(t *testing.T) {
+	m := buildBindingRequestWithChange(t, 0x06)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if !ip || !port || !ok {
+		t.Fatalf("got (%v, %v, %v), want (true, true, true)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_ChangeIPOnly(t *testing.T) {
+	m := buildBindingRequestWithChange(t, 0x04)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if !ip || port || !ok {
+		t.Fatalf("got (%v, %v, %v), want (true, false, true)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_ChangePortOnly(t *testing.T) {
+	m := buildBindingRequestWithChange(t, 0x02)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if ip || !port || !ok {
+		t.Fatalf("got (%v, %v, %v), want (false, true, true)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_NoFlags(t *testing.T) {
+	m := buildBindingRequestWithChange(t, 0x00)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if ip || port || !ok {
+		t.Fatalf("got (%v, %v, %v), want (false, false, true)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_ReservedBitsIgnored(t *testing.T) {
+	// All bits set; A=0x04, B=0x02 extracted, others ignored.
+	m := buildBindingRequestWithChange(t, 0xFFFFFFFF)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if !ip || !port || !ok {
+		t.Fatalf("got (%v, %v, %v), want (true, true, true)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_NoAttribute(t *testing.T) {
+	m := mustEncodeBindingRequest(t)
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if ip || port || ok {
+		t.Fatalf("got (%v, %v, %v), want (false, false, false)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_WrongMessageType(t *testing.T) {
+	cases := []struct {
+		name  string
+		build func(t *testing.T) *stun.Message
+	}{
+		{"BindingError", func(t *testing.T) *stun.Message {
+			m, err := stun.Build(stun.TransactionID, stun.BindingError)
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			m.Encode()
+			return m
+		}},
+		{"BindingSuccess_with_CHANGE-REQUEST", func(t *testing.T) *stun.Message {
+			var v [4]byte
+			binary.BigEndian.PutUint32(v[:], 0x06)
+			m, err := stun.Build(stun.TransactionID, stun.BindingSuccess, stun.RawAttribute{
+				Type:   stun.AttrChangeRequest,
+				Length: 4,
+				Value:  v[:],
+			})
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			m.Encode()
+			return m
+		}},
+		{"AllocateRequest", func(t *testing.T) *stun.Message {
+			allocate := stun.NewType(stun.MethodAllocate, stun.ClassRequest)
+			m, err := stun.Build(stun.TransactionID, allocate)
+			if err != nil {
+				t.Fatalf("build: %v", err)
+			}
+			m.Encode()
+			return m
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := tc.build(t)
+			ip, port, ok := ParseChangeRequest(m.Raw)
+			if ip || port || ok {
+				t.Fatalf("got (%v, %v, %v), want (false, false, false)", ip, port, ok)
+			}
+		})
+	}
+}
+
+func TestParseChangeRequest_Malformed(t *testing.T) {
+	cases := [][]byte{
+		nil,
+		{},
+		{0xff, 0xff},
+		make([]byte, 100),
+	}
+	// The 100-byte zeroed slice would parse as a Binding-Request method (type
+	// = 0x0000) with a header but no attributes; ensure it returns
+	// (false,false,false) because there's no CHANGE-REQUEST attribute.
+	for i, in := range cases {
+		ip, port, ok := ParseChangeRequest(in)
+		if ip || port || ok {
+			t.Fatalf("case %d: got (%v, %v, %v), want (false, false, false)", i, ip, port, ok)
+		}
+	}
+}
+
+func TestParseChangeRequest_WrongAttrLen(t *testing.T) {
+	// CHANGE-REQUEST with 8-byte payload (RFC mandates 4).
+	m, err := stun.Build(stun.TransactionID, stun.BindingRequest, stun.RawAttribute{
+		Type:   stun.AttrChangeRequest,
+		Length: 8,
+		Value:  []byte{0, 0, 0, 0, 0, 0, 0, 0},
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m.Encode()
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if ip || port || ok {
+		t.Fatalf("got (%v, %v, %v), want (false, false, false)", ip, port, ok)
+	}
+}
+
+func TestParseChangeRequest_DuplicateAttribute(t *testing.T) {
+	// Two CHANGE-REQUEST attributes with different flags. Pion's Get returns
+	// the first; document this behavior.
+	var first, second [4]byte
+	binary.BigEndian.PutUint32(first[:], 0x04)  // change-IP only
+	binary.BigEndian.PutUint32(second[:], 0x02) // change-PORT only
+	m, err := stun.Build(stun.TransactionID, stun.BindingRequest,
+		stun.RawAttribute{Type: stun.AttrChangeRequest, Length: 4, Value: first[:]},
+		stun.RawAttribute{Type: stun.AttrChangeRequest, Length: 4, Value: second[:]},
+	)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	m.Encode()
+	ip, port, ok := ParseChangeRequest(m.Raw)
+	if !ok {
+		t.Fatal("ok = false; expected first-wins parsing")
+	}
+	if !ip || port {
+		t.Fatalf("got (%v, %v, %v), want first-wins (true, false, true)", ip, port, ok)
 	}
 }

--- a/internal/stunserver/server_test.go
+++ b/internal/stunserver/server_test.go
@@ -301,6 +301,32 @@ func TestHandle_OtherAddressAbsent(t *testing.T) {
 	}
 }
 
+func TestHandle_SrcUnmapsToIPv4(t *testing.T) {
+	// IPv4-mapped IPv6 src must be encoded as IPv4 family in XOR-MAPPED-ADDRESS.
+	// Guards the src.Addr().Unmap() defensive call in Handle.
+	s := New(Options{})
+	req := mustEncodeBindingRequest(t)
+	mappedSrc := netip.AddrPortFrom(netip.MustParseAddr("::ffff:192.0.2.1"), 51234)
+
+	out := s.Handle(req.Raw, mappedSrc)
+	resp := &stun.Message{Raw: out}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var xor stun.XORMappedAddress
+	if err := xor.GetFrom(resp); err != nil {
+		t.Fatalf("XOR-MAPPED-ADDRESS missing: %v", err)
+	}
+	if len(xor.IP) != 4 {
+		t.Fatalf("XOR-MAPPED-ADDRESS IP length = %d, want 4 (IPv4 family)", len(xor.IP))
+	}
+	gotIP, _ := netip.AddrFromSlice(xor.IP)
+	wantIP := netip.MustParseAddr("192.0.2.1")
+	if gotIP.Unmap() != wantIP {
+		t.Fatalf("XOR-MAPPED-ADDRESS IP = %v, want %v", gotIP.Unmap(), wantIP)
+	}
+}
+
 func TestHandle_OtherAddressUnmaps(t *testing.T) {
 	// IPv4-mapped IPv6 address must be encoded as IPv4 family in OTHER-ADDRESS.
 	mapped := netip.AddrPortFrom(netip.MustParseAddr("::ffff:192.0.2.1"), 3479)


### PR DESCRIPTION
v0.1.2 phase 2 of 5. `Handle` emits OTHER-ADDRESS attribute when `Options.Other` is set. New `ParseChangeRequest` package function extracts CHANGE-REQUEST flags. Phase-1 `Handle` signature preserved; phase-1 tests unchanged. Defensive `.Unmap()` applied to `src.Addr()` (closes phase-1 borderline issue #4).

No CLI / JSON / classifier impact.

## Verification

- `go vet`, `gofmt`, `go mod tidy -diff` clean
- `make test` (5 packages, race, 60s) green
- `make lint` 0 issues
- `internal/stunserver/` coverage 90.0%
- `go test -race -count=3` no flake