### PR TITLE
feat(probe): add RFC 5780 §4.4 filtering probe and stunserver helpers

### DIFF
--- a/internal/probe/filtering.go
+++ b/internal/probe/filtering.go
@@ -1,0 +1,188 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"strconv"
+	"time"
+
+	"github.com/1mb-dev/natcheck/internal/stunserver"
+	"github.com/pion/stun/v3"
+)
+
+// FilteringResult captures the outcome of an RFC 5780 §4.4 three-step
+// filtering classification. Test1Other.IsValid() == false means the server
+// did not advertise OTHER-ADDRESS; in that case Test2Received and
+// Test3Received are both false and Err wraps ErrFilteringNotSupported.
+type FilteringResult struct {
+	Test1Mapped   netip.AddrPort
+	Test1Other    netip.AddrPort
+	Test2Received bool
+	Test3Received bool
+	Err           error
+}
+
+// ErrFilteringNotSupported is returned in FilteringResult.Err when the target
+// server's BindingResponse does not include an OTHER-ADDRESS attribute, so the
+// §4.4 sequence cannot be attempted.
+var ErrFilteringNotSupported = errors.New("server did not advertise OTHER-ADDRESS")
+
+// ErrTest1Failed wraps the underlying transport / parse error from the initial
+// Binding probe. The §4.4 sequence is skipped when this error is returned.
+var ErrTest1Failed = errors.New("initial probe failed; cannot run §4.4 sequence")
+
+// errNoResponse signals "no STUN response arrived before the per-test deadline."
+// Package-internal: callers in this file translate it to Test{2,3}Received=false.
+var errNoResponse = errors.New("no response within deadline")
+
+// ProbeFiltering runs RFC 5780 §4.4 against server. Uses one unconnected UDP
+// socket for all three tests so (a) the NAT mapping stays stable across tests
+// and (b) the socket can receive responses from the server's alt-IP/alt-port
+// sources (a connected UDP socket would filter those out). Tests 2/3 are
+// one-shot; "no response within timeout/2" is the verdict, not an error.
+//
+// ctx governs the initial address resolution only; once resolution completes,
+// per-test SetReadDeadline timers (timeout/2 each) drive the rest. Cancelling
+// ctx mid-call has no effect on in-flight reads.
+func ProbeFiltering(ctx context.Context, server Server, timeout time.Duration) FilteringResult {
+	res := FilteringResult{}
+	if server.Host == "" || server.Port <= 0 || server.Port > 65535 {
+		res.Err = fmt.Errorf("invalid server %q:%d", server.Host, server.Port)
+		return res
+	}
+
+	hostport := net.JoinHostPort(server.Host, strconv.Itoa(server.Port))
+	var resolver net.Resolver
+	ips, err := resolver.LookupNetIP(ctx, "ip", server.Host)
+	if err != nil {
+		res.Err = fmt.Errorf("resolve %s: %w", server.Host, err)
+		return res
+	}
+	if len(ips) == 0 {
+		res.Err = fmt.Errorf("resolve %s: no addresses", server.Host)
+		return res
+	}
+	remote := &net.UDPAddr{IP: net.IP(ips[0].Unmap().AsSlice()), Port: server.Port}
+
+	conn, err := net.ListenPacket("udp", ":0")
+	if err != nil {
+		res.Err = fmt.Errorf("listen %s: %w", hostport, err)
+		return res
+	}
+	defer func() { _ = conn.Close() }()
+
+	perTest := timeout / 2
+	if perTest <= 0 {
+		perTest = 500 * time.Millisecond
+	}
+
+	// Test 1: plain Binding.
+	t1, err := sendBindingAndWait(conn, remote, perTest, nil)
+	if err != nil {
+		res.Err = fmt.Errorf("%w: %w", ErrTest1Failed, err)
+		return res
+	}
+	res.Test1Mapped = t1.mapped
+	res.Test1Other = t1.other
+
+	if !res.Test1Other.IsValid() {
+		res.Err = ErrFilteringNotSupported
+		return res
+	}
+
+	// Test 2: CHANGE-IP|CHANGE-PORT.
+	t2, _ := sendBindingAndWait(conn, remote, perTest, &changeRequestPayload{ip: true, port: true})
+	res.Test2Received = t2 != nil
+
+	// Test 3: CHANGE-PORT.
+	t3, _ := sendBindingAndWait(conn, remote, perTest, &changeRequestPayload{ip: false, port: true})
+	res.Test3Received = t3 != nil
+
+	return res
+}
+
+type bindingResult struct {
+	mapped netip.AddrPort
+	other  netip.AddrPort
+}
+
+type changeRequestPayload struct {
+	ip, port bool
+}
+
+// sendBindingAndWait sends one BindingRequest (with optional CHANGE-REQUEST)
+// to remote and waits up to deadline for a matching response. The conn is an
+// unconnected PacketConn so responses can arrive from sources other than
+// remote (RFC 5780 §4.4: server replies from alt-IP/alt-port). Returns
+// errNoResponse if the deadline expires with no matching reply. Discards
+// stale packets with non-matching transaction IDs (e.g., late responses from
+// a prior test) and keeps reading until either a matching response, deadline
+// expiry, or fatal socket error.
+func sendBindingAndWait(conn net.PacketConn, remote net.Addr, deadline time.Duration, change *changeRequestPayload) (*bindingResult, error) {
+	setters := []stun.Setter{stun.TransactionID, stun.BindingRequest}
+	if change != nil {
+		setters = append(setters, stunserver.BuildChangeRequest(change.ip, change.port))
+	}
+	req, err := stun.Build(setters...)
+	if err != nil {
+		return nil, fmt.Errorf("build: %w", err)
+	}
+	req.Encode()
+
+	end := time.Now().Add(deadline)
+	if err := conn.SetWriteDeadline(end); err != nil {
+		return nil, fmt.Errorf("set write deadline: %w", err)
+	}
+	if _, err := conn.WriteTo(req.Raw, remote); err != nil {
+		return nil, fmt.Errorf("write: %w", err)
+	}
+
+	buf := make([]byte, 1500)
+	for {
+		if time.Until(end) <= 0 {
+			return nil, errNoResponse
+		}
+		if err := conn.SetReadDeadline(end); err != nil {
+			return nil, fmt.Errorf("set read deadline: %w", err)
+		}
+		n, _, err := conn.ReadFrom(buf)
+		if err != nil {
+			// Deadline reached or fatal error.
+			return nil, errNoResponse
+		}
+		resp := &stun.Message{Raw: append([]byte{}, buf[:n]...)}
+		if err := resp.Decode(); err != nil {
+			// Garbage on the socket; discard and keep reading.
+			continue
+		}
+		if resp.TransactionID != req.TransactionID {
+			// Stale response from a prior test; discard and keep reading.
+			continue
+		}
+		if resp.Type != stun.BindingSuccess {
+			return nil, fmt.Errorf("unexpected message type: %s", resp.Type)
+		}
+		var xor stun.XORMappedAddress
+		if err := xor.GetFrom(resp); err != nil {
+			return nil, fmt.Errorf("XOR-MAPPED-ADDRESS: %w", err)
+		}
+		mappedIP, ok := netip.AddrFromSlice(xor.IP)
+		if !ok {
+			return nil, errors.New("invalid mapped IP")
+		}
+		out := &bindingResult{
+			mapped: netip.AddrPortFrom(mappedIP.Unmap(), uint16(xor.Port)),
+		}
+		var oa stun.OtherAddress
+		if err := oa.GetFrom(resp); err == nil {
+			otherIP, ok := netip.AddrFromSlice(oa.IP)
+			if ok {
+				out.other = netip.AddrPortFrom(otherIP.Unmap(), uint16(oa.Port))
+			}
+		}
+		return out, nil
+	}
+}

--- a/internal/probe/filtering_test.go
+++ b/internal/probe/filtering_test.go
@@ -1,0 +1,351 @@
+package probe
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/1mb-dev/natcheck/internal/stunserver"
+)
+
+// corner identifies one of the four §3 listeners.
+type corner int
+
+const (
+	cornerPrimary corner = iota // (IP1, port1)
+	cornerAltPort               // (IP1, port2) — CHANGE-PORT
+	cornerAltIP                 // (IP2, port1) — CHANGE-IP
+	cornerAltBoth               // (IP2, port2) — CHANGE-IP|CHANGE-PORT
+)
+
+// fakeFilteringServer is a 4-corner §3 STUN responder for in-process tests.
+// Per-corner dropPolicy controls whether responses from that corner are sent
+// (simulates filtering NAT behavior on the client side).
+//
+// Corner indices: 0=primary (IP1,port1), 1=alt-port (IP1,port2),
+// 2=alt-IP (IP2,port1), 3=alt-both (IP2,port2). Diagonal pairs: 0<->3, 1<->2.
+// In loopback tests "IP1" and "IP2" both resolve to 127.0.0.1; the four corners
+// differ only by port — sufficient for §4.4 routing semantics.
+type fakeFilteringServer struct {
+	conns        [4]net.PacketConn
+	addrs        [4]netip.AddrPort
+	dropFrom     map[corner]bool
+	mu           sync.Mutex
+	respondCount int
+	noiseAfter   int // if > 0, dispatcher injects one bogus-TXID packet after the Nth real response
+	done         chan struct{}
+	wg           sync.WaitGroup
+}
+
+// setNoiseAfter wires the regression-test knob: after the Nth real response,
+// the dispatcher injects one bogus-TXID packet to the client. Mutex-protected
+// so the dispatcher's read is race-free.
+func (f *fakeFilteringServer) setNoiseAfter(n int) {
+	f.mu.Lock()
+	f.noiseAfter = n
+	f.mu.Unlock()
+}
+
+// newFakeFilteringServer binds 4 loopback sockets and starts a single reader
+// goroutine per conn plus a dispatcher that routes incoming requests per
+// RFC 5780 §3 / §4.4.
+func newFakeFilteringServer(t *testing.T, dropFrom ...corner) *fakeFilteringServer {
+	t.Helper()
+	f := &fakeFilteringServer{
+		dropFrom: make(map[corner]bool),
+		done:     make(chan struct{}),
+	}
+	for _, c := range dropFrom {
+		f.dropFrom[c] = true
+	}
+	for i := range f.conns {
+		c, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen %d: %v", i, err)
+		}
+		f.conns[i] = c
+		u := c.LocalAddr().(*net.UDPAddr)
+		a, _ := netip.AddrFromSlice(u.IP)
+		f.addrs[i] = netip.AddrPortFrom(a.Unmap(), uint16(u.Port))
+	}
+	f.wg.Add(1)
+	go f.serve()
+	t.Cleanup(func() {
+		close(f.done)
+		for _, c := range f.conns {
+			_ = c.Close()
+		}
+		f.wg.Wait()
+	})
+	return f
+}
+
+func (f *fakeFilteringServer) primaryServer() Server {
+	return Server{Host: "127.0.0.1", Port: int(f.addrs[cornerPrimary].Port())}
+}
+
+// otherFor returns the diagonal corner's address for OTHER-ADDRESS in responses
+// originating from the given corner. Diagonal pairs: 0<->3, 1<->2.
+func (f *fakeFilteringServer) otherFor(c corner) netip.AddrPort {
+	diagonal := []corner{cornerAltBoth, cornerAltIP, cornerAltPort, cornerPrimary}
+	return f.addrs[diagonal[c]]
+}
+
+func (f *fakeFilteringServer) serve() {
+	defer f.wg.Done()
+	type packet struct {
+		from corner
+		data []byte
+		src  net.Addr
+	}
+	ch := make(chan packet, 16)
+	// Per-conn read pumps; tracked in f.wg so Cleanup waits for them.
+	for i, c := range f.conns {
+		i, c := corner(i), c
+		f.wg.Add(1)
+		go func() {
+			defer f.wg.Done()
+			buf := make([]byte, 1500)
+			for {
+				_ = c.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+				n, src, err := c.ReadFrom(buf)
+				if err != nil {
+					select {
+					case <-f.done:
+						return
+					default:
+						continue
+					}
+				}
+				cp := append([]byte{}, buf[:n]...)
+				select {
+				case ch <- packet{from: i, data: cp, src: src}:
+				case <-f.done:
+					return
+				}
+			}
+		}()
+	}
+	for {
+		select {
+		case <-f.done:
+			return
+		case p := <-ch:
+			f.dispatch(p.from, p.data, p.src)
+		}
+	}
+}
+
+// dispatch parses CHANGE-REQUEST on the inbound packet, routes the response
+// to the correct outbound corner per RFC 5780 §3, and writes from that corner.
+func (f *fakeFilteringServer) dispatch(received corner, data []byte, src net.Addr) {
+	changeIP, changePort, ok := stunserver.ParseChangeRequest(data)
+	target := received
+	if ok {
+		switch {
+		case changeIP && changePort:
+			target = altIPAltPortFrom(received)
+		case changeIP:
+			target = altIPFrom(received)
+		case changePort:
+			target = altPortFrom(received)
+		}
+	}
+	f.respond(target, data, src)
+}
+
+// respond builds the response on `target`'s Server (so OTHER-ADDRESS reflects
+// target's diagonal) and writes from `target`'s conn — unless dropFrom[target].
+// If noiseAfterReq is set, injects one bogus-TXID packet to the client after
+// the Nth real response (used by TestProbeFiltering_StalePacketDoesNotPollute).
+func (f *fakeFilteringServer) respond(target corner, data []byte, src net.Addr) {
+	if f.dropFrom[target] {
+		return
+	}
+	udp, ok := src.(*net.UDPAddr)
+	if !ok {
+		return
+	}
+	ipa, _ := netip.AddrFromSlice(udp.IP)
+	srcAP := netip.AddrPortFrom(ipa.Unmap(), uint16(udp.Port))
+	s := stunserver.New(stunserver.Options{Other: f.otherFor(target)})
+	resp := s.Handle(data, srcAP)
+	if resp == nil {
+		return
+	}
+	_, _ = f.conns[target].WriteTo(resp, src)
+
+	f.mu.Lock()
+	f.respondCount++
+	count := f.respondCount
+	noise := f.noiseAfter
+	f.mu.Unlock()
+	if noise > 0 && count == noise {
+		// Send a bogus packet that fails STUN Decode. sendBindingAndWait must
+		// loop on the decode failure and read the next packet within deadline.
+		junk := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+		_, _ = f.conns[target].WriteTo(junk, src)
+	}
+}
+
+// Corner-routing helpers. Indexed by inbound corner; value is the outbound
+// corner that should send the response. Per RFC 5780 §3, "alt-IP" flips IP1↔IP2,
+// "alt-port" flips port1↔port2, "alt-IP+alt-port" flips both (= the diagonal).
+//
+// Corner numbering (see fakeFilteringServer doc): 0=primary, 1=alt-port,
+// 2=alt-IP, 3=alt-both. Diagonals: 0↔3, 1↔2.
+//
+//	inbound:           0  1  2  3
+//	alt-IP only:       2  3  0  1   (flip IP)
+//	alt-port only:     1  0  3  2   (flip port)
+//	alt-IP+alt-port:   3  2  1  0   (flip both = diagonal)
+func altIPFrom(c corner) corner {
+	return [4]corner{cornerAltIP, cornerAltBoth, cornerPrimary, cornerAltPort}[c]
+}
+func altPortFrom(c corner) corner {
+	return [4]corner{cornerAltPort, cornerPrimary, cornerAltBoth, cornerAltIP}[c]
+}
+func altIPAltPortFrom(c corner) corner {
+	return [4]corner{cornerAltBoth, cornerAltIP, cornerAltPort, cornerPrimary}[c]
+}
+
+// --- tests ---
+
+func TestProbeFiltering_EndpointIndependent(t *testing.T) {
+	f := newFakeFilteringServer(t) // no drops
+	res := ProbeFiltering(context.Background(), f.primaryServer(), 2*time.Second)
+	if res.Err != nil {
+		t.Fatalf("Err = %v, want nil", res.Err)
+	}
+	if !res.Test2Received || !res.Test3Received {
+		t.Fatalf("got Test2=%v Test3=%v, want both true", res.Test2Received, res.Test3Received)
+	}
+	if !res.Test1Other.IsValid() {
+		t.Fatal("Test1Other should be set")
+	}
+}
+
+func TestProbeFiltering_AddressDependent(t *testing.T) {
+	// Drop responses from the alt-IP+alt-port corner (Test 2's target).
+	f := newFakeFilteringServer(t, cornerAltBoth)
+	res := ProbeFiltering(context.Background(), f.primaryServer(), 2*time.Second)
+	if res.Err != nil {
+		t.Fatalf("Err = %v, want nil", res.Err)
+	}
+	if res.Test2Received {
+		t.Fatal("Test2 received; want dropped")
+	}
+	if !res.Test3Received {
+		t.Fatal("Test3 not received; want received")
+	}
+}
+
+func TestProbeFiltering_AddressAndPortDependent(t *testing.T) {
+	f := newFakeFilteringServer(t, cornerAltBoth, cornerAltPort)
+	res := ProbeFiltering(context.Background(), f.primaryServer(), 2*time.Second)
+	if res.Err != nil {
+		t.Fatalf("Err = %v, want nil", res.Err)
+	}
+	if res.Test2Received || res.Test3Received {
+		t.Fatalf("got Test2=%v Test3=%v, want both false", res.Test2Received, res.Test3Received)
+	}
+}
+
+func TestProbeFiltering_NoOtherAddress(t *testing.T) {
+	// Bind a single conn that responds without OTHER-ADDRESS (phase-1 stunserver).
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = stunserver.New(stunserver.Options{}).Serve(ctx, conn) }()
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+
+	res := ProbeFiltering(context.Background(), Server{Host: "127.0.0.1", Port: port}, time.Second)
+	if !errors.Is(res.Err, ErrFilteringNotSupported) {
+		t.Fatalf("Err = %v, want ErrFilteringNotSupported", res.Err)
+	}
+	if res.Test2Received || res.Test3Received {
+		t.Fatal("Test2/3 should be false when not supported")
+	}
+}
+
+func TestProbeFiltering_Test1Failed(t *testing.T) {
+	// Grab a port then free it.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	_ = conn.Close()
+
+	res := ProbeFiltering(context.Background(), Server{Host: "127.0.0.1", Port: port}, 200*time.Millisecond)
+	if !errors.Is(res.Err, ErrTest1Failed) {
+		t.Fatalf("Err = %v, want ErrTest1Failed", res.Err)
+	}
+}
+
+func TestProbeFiltering_InvalidServer(t *testing.T) {
+	res := ProbeFiltering(context.Background(), Server{Host: "", Port: 3478}, time.Second)
+	if res.Err == nil {
+		t.Fatal("expected error for empty host")
+	}
+}
+
+func TestProbeFiltering_ZeroTimeoutFallsBack(t *testing.T) {
+	// timeout=0 must not hang; sendBindingAndWait falls back to 500ms per test.
+	f := newFakeFilteringServer(t)
+	start := time.Now()
+	res := ProbeFiltering(context.Background(), f.primaryServer(), 0)
+	if res.Err != nil {
+		t.Fatalf("Err = %v, want nil", res.Err)
+	}
+	// Worst case: 3 tests × 500ms each = 1.5s; loopback should be much faster.
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("elapsed %v exceeds fallback budget", elapsed)
+	}
+}
+
+func TestProbeFiltering_CtxCancelAfterDial(t *testing.T) {
+	// Per godoc: ctx governs dial only. A cancel after dial does NOT abort.
+	f := newFakeFilteringServer(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancelled := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+		close(cancelled)
+	}()
+	res := ProbeFiltering(ctx, f.primaryServer(), 2*time.Second)
+	<-cancelled
+	if res.Err != nil {
+		t.Fatalf("Err = %v; ctx cancellation after dial must not abort", res.Err)
+	}
+}
+
+func TestProbeFiltering_StalePacketDoesNotPollute(t *testing.T) {
+	// Regression: late response from a prior test must not cause Test 3 to
+	// record "no response". sendBindingAndWait must discard mismatched-TXID
+	// packets and keep reading within the deadline.
+	//
+	// Setup: noiseAfter=2 means the dispatcher sends a junk packet to the
+	// client immediately after answering Test 2 — that junk packet sits in the
+	// kernel buffer when Test 3 starts reading. With the loop-on-mismatch fix,
+	// sendBindingAndWait discards the junk and keeps reading for Test 3's
+	// real response.
+	f := newFakeFilteringServer(t)
+	f.setNoiseAfter(2)
+	res := ProbeFiltering(context.Background(), f.primaryServer(), 2*time.Second)
+	if res.Err != nil {
+		t.Fatalf("Err = %v", res.Err)
+	}
+	if !res.Test2Received || !res.Test3Received {
+		t.Fatalf("Test2=%v Test3=%v; baseline must be EIF even with noise injection", res.Test2Received, res.Test3Received)
+	}
+}

--- a/internal/probe/filtering_test.go
+++ b/internal/probe/filtering_test.go
@@ -160,8 +160,8 @@ func (f *fakeFilteringServer) dispatch(received corner, data []byte, src net.Add
 
 // respond builds the response on `target`'s Server (so OTHER-ADDRESS reflects
 // target's diagonal) and writes from `target`'s conn — unless dropFrom[target].
-// If noiseAfterReq is set, injects one bogus-TXID packet to the client after
-// the Nth real response (used by TestProbeFiltering_StalePacketDoesNotPollute).
+// If noiseAfter is set, injects one packet that fails STUN Decode after the
+// Nth real response (used by TestProbeFiltering_StalePacketDoesNotPollute).
 func (f *fakeFilteringServer) respond(target corner, data []byte, src net.Addr) {
 	if f.dropFrom[target] {
 		return

--- a/internal/stunserver/server.go
+++ b/internal/stunserver/server.go
@@ -122,6 +122,22 @@ func (s *Server) Serve(ctx context.Context, conn net.PacketConn) error {
 	}
 }
 
+// BuildChangeRequest returns a CHANGE-REQUEST attribute (RFC 5780 §7.2)
+// suitable for passing to stun.Build alongside other setters. Bit A (0x04)
+// requests CHANGE-IP; bit B (0x02) requests CHANGE-PORT.
+func BuildChangeRequest(changeIP, changePort bool) stun.RawAttribute {
+	var v uint32
+	if changeIP {
+		v |= 0x04
+	}
+	if changePort {
+		v |= 0x02
+	}
+	var b [4]byte
+	binary.BigEndian.PutUint32(b[:], v)
+	return stun.RawAttribute{Type: stun.AttrChangeRequest, Length: 4, Value: b[:]}
+}
+
 // ParseChangeRequest extracts CHANGE-REQUEST flags from a STUN BindingRequest.
 // Returns ok=false for messages other than BindingRequest, malformed STUN,
 // missing CHANGE-REQUEST attribute, or attribute payloads not exactly 4 bytes.

--- a/internal/stunserver/server_external_test.go
+++ b/internal/stunserver/server_external_test.go
@@ -1,0 +1,89 @@
+// External test package — breaks the import cycle that arises when
+// internal/probe imports internal/stunserver (production) AND a stunserver
+// test wants to drive Serve via internal/probe (test-only).
+package stunserver_test
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/1mb-dev/natcheck/internal/probe"
+	"github.com/1mb-dev/natcheck/internal/stunserver"
+	"github.com/pion/stun/v3"
+)
+
+func TestServe_RoundTrip(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	udpAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- stunserver.New(stunserver.Options{}).Serve(ctx, conn) }()
+
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), time.Second)
+	defer probeCancel()
+	res := probe.NewSTUN().Probe(probeCtx, probe.Server{Host: "127.0.0.1", Port: udpAddr.Port})
+	if res.Err != nil {
+		t.Fatalf("probe: %v", res.Err)
+	}
+	if !res.Mapped.Addr().IsLoopback() {
+		t.Fatalf("mapped = %v, want loopback", res.Mapped.Addr())
+	}
+
+	cancel()
+	select {
+	case err := <-serveDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("serve returned %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("serve did not return within 1s of cancel")
+	}
+}
+
+func TestBuildChangeRequest_RoundTrip(t *testing.T) {
+	cases := []struct{ ip, port bool }{
+		{false, false},
+		{true, false},
+		{false, true},
+		{true, true},
+	}
+	for _, c := range cases {
+		attr := stunserver.BuildChangeRequest(c.ip, c.port)
+		if attr.Type != stun.AttrChangeRequest {
+			t.Fatalf("(%v,%v): attr.Type = %v, want AttrChangeRequest", c.ip, c.port, attr.Type)
+		}
+		if len(attr.Value) != 4 {
+			t.Fatalf("(%v,%v): attr.Value length = %d, want 4", c.ip, c.port, len(attr.Value))
+		}
+		// Sanity-check the byte payload directly: bit A = 0x04, bit B = 0x02.
+		flags := binary.BigEndian.Uint32(attr.Value)
+		wantIP := flags&0x04 != 0
+		wantPort := flags&0x02 != 0
+		if wantIP != c.ip || wantPort != c.port {
+			t.Fatalf("(%v,%v): payload bits decode as (%v,%v)", c.ip, c.port, wantIP, wantPort)
+		}
+		// Build a full message and round-trip through ParseChangeRequest.
+		m, err := stun.Build(stun.TransactionID, stun.BindingRequest, attr)
+		if err != nil {
+			t.Fatalf("(%v,%v) build: %v", c.ip, c.port, err)
+		}
+		m.Encode()
+		gotIP, gotPort, ok := stunserver.ParseChangeRequest(m.Raw)
+		if !ok {
+			t.Fatalf("(%v,%v): ParseChangeRequest ok=false", c.ip, c.port)
+		}
+		if gotIP != c.ip || gotPort != c.port {
+			t.Fatalf("(%v,%v) round-trip got (%v,%v)", c.ip, c.port, gotIP, gotPort)
+		}
+	}
+}

--- a/internal/stunserver/server_test.go
+++ b/internal/stunserver/server_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/1mb-dev/natcheck/internal/probe"
 	"github.com/pion/stun/v3"
 )
 
@@ -136,40 +135,6 @@ func TestHandle_Garbled(t *testing.T) {
 	}
 	if out := s.Handle(garbage, netip.MustParseAddrPort("127.0.0.1:1")); out != nil {
 		t.Fatalf("expected nil for garbled input, got %d bytes", len(out))
-	}
-}
-
-func TestServe_RoundTrip(t *testing.T) {
-	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-	udpAddr := conn.LocalAddr().(*net.UDPAddr)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	serveDone := make(chan error, 1)
-	go func() { serveDone <- New(Options{}).Serve(ctx, conn) }()
-
-	probeCtx, probeCancel := context.WithTimeout(context.Background(), time.Second)
-	defer probeCancel()
-	res := probe.NewSTUN().Probe(probeCtx, probe.Server{Host: "127.0.0.1", Port: udpAddr.Port})
-	if res.Err != nil {
-		t.Fatalf("probe: %v", res.Err)
-	}
-	if !res.Mapped.Addr().IsLoopback() {
-		t.Fatalf("mapped = %v, want loopback", res.Mapped.Addr())
-	}
-
-	cancel()
-	select {
-	case err := <-serveDone:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("serve returned %v, want context.Canceled", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("serve did not return within 1s of cancel")
 	}
 }
 


### PR DESCRIPTION
v0.1.2 phase 3 of 5. Probe-side §4.4 sequence + stunserver helpers + multi-socket in-process test backend. No CLI / JSON / classifier impact.

**stunserver:** new `BuildChangeRequest` (pairs with phase-2's `ParseChangeRequest`).

**probe:** new `ProbeFiltering(ctx, server, timeout) FilteringResult` runs Tests 1/2/3 from one unconnected UDP socket so responses from alt-IP/alt-port sources are accepted (a connected UDP socket would filter them). Sentinel errors `ErrFilteringNotSupported` and `ErrTest1Failed` for phase-4 classifier consumption. `sendBindingAndWait` loops on TX-ID mismatch within deadline so stale packets from a prior test don't pollute the next test's verdict.

**Test backend:** `fakeFilteringServer` owns 4 loopback PacketConns + 5 goroutines (4 read pumps + 1 dispatcher), routes via `ParseChangeRequest`, builds responses via `Handle`. Per-corner drop policy simulates filtering NAT outcomes. `TestServe_RoundTrip` moves to an external test package to break the new probe→stunserver import cycle.

## Verification

- `go vet`, `gofmt`, `go mod tidy -diff` clean
- `make test` (5 packages, race, 60s) green
- `make lint` 0 issues
- `internal/probe/` coverage 81.8%; `internal/stunserver/` coverage 91.4%