### PR TITLE
feat: classifier consumes filtering, JSON gains filtering object, CLI wires it

### DIFF
--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -2,11 +2,13 @@
 //
 // Classification follows RFC 5780 mapping-behavior categories
 // (Endpoint-Independent, Address-Dependent, Address and Port-Dependent) and
-// emits legacy RFC 3489 terms ("cone", "symmetric") for human readers. See
-// docs/design.md for the v0.1 scope and limits.
+// emits legacy RFC 3489 terms ("cone", "symmetric") for human readers.
+// Optional filtering data (RFC 5780 §4.4) refines the WebRTC forecast when
+// the target server supports CHANGE-REQUEST. See docs/design.md.
 package classify
 
 import (
+	"errors"
 	"net/netip"
 
 	"github.com/1mb-dev/natcheck/internal/probe"
@@ -57,30 +59,69 @@ func (t NATType) String() string {
 	}
 }
 
+// FilteringBehavior is the RFC 5780 §4.4 filtering category.
+type FilteringBehavior int
+
+const (
+	// FilteringUntested is the zero value: no §4.4 sequence ran (server didn't
+	// support OTHER-ADDRESS, or filtering wasn't attempted).
+	FilteringUntested FilteringBehavior = iota
+	// FilteringEndpointIndependent: replies arrive from any source the server
+	// is asked to use (Test 2 + Test 3 both received).
+	FilteringEndpointIndependent
+	// FilteringAddressDependent: replies arrive when source IP matches a peer
+	// the client has communicated with (Test 2 dropped, Test 3 received).
+	FilteringAddressDependent
+	// FilteringAddressAndPortDependent: replies arrive only when both source
+	// IP and port match (Test 2 + Test 3 both dropped).
+	FilteringAddressAndPortDependent
+)
+
+// String returns the canonical wire name (matches the JSON enum).
+func (b FilteringBehavior) String() string {
+	switch b {
+	case FilteringEndpointIndependent:
+		return "endpoint-independent"
+	case FilteringAddressDependent:
+		return "address-dependent"
+	case FilteringAddressAndPortDependent:
+		return "address-and-port-dependent"
+	default:
+		return "untested"
+	}
+}
+
 // Forecast is the WebRTC direct-P2P prediction.
 type Forecast struct {
-	DirectP2P    string // "likely" | "possible" | "unlikely" | "unknown" (v0.1 emits {likely, unlikely, unknown}; "possible" reserved for v0.2 filtering + CGNAT calibration)
+	DirectP2P    string // "likely" | "possible" | "unlikely" | "unknown"
 	TURNRequired bool
 }
 
 // Verdict is the final classification output.
 type Verdict struct {
-	Type            NATType
-	LegacyName      string // "cone", "symmetric", "" when unknown/blocked
-	PublicEndpoint  netip.AddrPort
-	CGNAT           bool
-	FilteringTested bool // always false in v0.1
-	Warnings        []string
-	Forecast        Forecast
+	Type           NATType
+	LegacyName     string // "cone", "symmetric", "" when unknown/blocked
+	PublicEndpoint netip.AddrPort
+	CGNAT          bool
+	// Filtering is the RFC 5780 §4.4 outcome; FilteringUntested when the
+	// §4.4 sequence did not run (no OTHER-ADDRESS support, or not attempted).
+	Filtering FilteringBehavior
+	// FilteringTestedAgainst is the server the §4.4 sequence ran against.
+	// Zero-value (Server{}) when filtering was not attempted, or when the
+	// server did not advertise OTHER-ADDRESS so no sequence ran.
+	FilteringTestedAgainst probe.Server
+	Warnings               []string
+	Forecast               Forecast
 }
 
 // Stable warning vocabulary for the JSON API.
 const (
-	WarnAllProbesFailed            = "all_probes_failed"
-	WarnADMOrStricter              = "adm_or_stricter"
-	WarnCGNATDetected              = "cgnat_detected"
-	WarnInsufficientProbes         = "insufficient_probes"
-	WarnFilteringBehaviorNotTested = "filtering_behavior_not_tested"
+	WarnAllProbesFailed                 = "all_probes_failed"
+	WarnADMOrStricter                   = "adm_or_stricter"
+	WarnCGNATDetected                   = "cgnat_detected"
+	WarnInsufficientProbes              = "insufficient_probes"
+	WarnFilteringBehaviorNotTested      = "filtering_behavior_not_tested"
+	WarnFilteringSkippedNoChangeRequest = "filtering_skipped_no_change_request"
 )
 
 // cgnatPrefix is RFC 6598 shared address space.
@@ -92,7 +133,22 @@ var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
 // A probe.Result is treated as successful only when Err == nil AND
 // Mapped.IsValid(). This guards against buggy Prober implementations that
 // might report nil-error with a zero mapped endpoint.
-func Classify(results []probe.Result) Verdict {
+//
+// filtering may be nil; in that case Verdict.Filtering stays Untested and
+// the existing WarnFilteringBehaviorNotTested warning is emitted. When
+// filtering is non-nil, its Test2/Test3 booleans drive the FilteringBehavior
+// and the WebRTC forecast for EIM mappings (RFC 5780 §4.4 outcomes).
+func Classify(results []probe.Result, filtering *probe.FilteringResult) Verdict {
+	v := classifyMapping(results)
+	applyFiltering(&v, filtering)
+	v.Forecast = decideForecast(v)
+	return v
+}
+
+// classifyMapping derives mapping behavior, public endpoint, CGNAT, and the
+// initial warning set. Forecast is computed by decideForecast after filtering
+// data is folded in.
+func classifyMapping(results []probe.Result) Verdict {
 	v := Verdict{Warnings: []string{WarnFilteringBehaviorNotTested}}
 
 	var successes []probe.Result
@@ -106,7 +162,6 @@ func Classify(results []probe.Result) Verdict {
 	case 0:
 		v.Type = Blocked
 		v.Warnings = append(v.Warnings, WarnAllProbesFailed)
-		v.Forecast = Forecast{DirectP2P: "unlikely", TURNRequired: true}
 		return v
 
 	case 1:
@@ -114,7 +169,6 @@ func Classify(results []probe.Result) Verdict {
 		v.PublicEndpoint = successes[0].Mapped
 		v.Warnings = append(v.Warnings, WarnInsufficientProbes)
 		applyCGNAT(&v)
-		v.Forecast = Forecast{DirectP2P: "unknown", TURNRequired: false}
 		return v
 
 	default:
@@ -129,20 +183,80 @@ func Classify(results []probe.Result) Verdict {
 		if allSame {
 			v.Type = EndpointIndependentMapping
 			v.LegacyName = "cone"
-			v.Forecast = Forecast{DirectP2P: "likely", TURNRequired: false}
 		} else {
 			v.Type = AddressDependentMapping
 			v.LegacyName = "symmetric"
 			v.Warnings = append(v.Warnings, WarnADMOrStricter)
-			v.Forecast = Forecast{DirectP2P: "unlikely", TURNRequired: true}
 		}
 		applyCGNAT(&v)
-		// v0.1: CGNAT forces forecast=unknown regardless of observed mapping —
-		// unknown is the honest answer when confident classification isn't possible.
-		if v.CGNAT {
-			v.Forecast = Forecast{DirectP2P: "unknown", TURNRequired: false}
-		}
 		return v
+	}
+}
+
+// applyFiltering folds *probe.FilteringResult into the verdict. Updates
+// v.Filtering, v.FilteringTestedAgainst, and v.Warnings.
+//
+// (T2=true, T3=false) is RFC-impossible per §4.4 — it implies the server
+// contradicted itself or the network corrupted Test 3 only. We drop to
+// FilteringUntested rather than over-claim a behavior the data doesn't show.
+func applyFiltering(v *Verdict, f *probe.FilteringResult) {
+	if f == nil {
+		return // Untested; existing WarnFilteringBehaviorNotTested already in v.Warnings.
+	}
+	if errors.Is(f.Err, probe.ErrFilteringNotSupported) {
+		// We tried, the server didn't support it. Replace the generic warning
+		// with the more specific one. FilteringTestedAgainst stays zero
+		// because no §4.4 sequence ran.
+		v.Warnings = replaceWarning(v.Warnings, WarnFilteringBehaviorNotTested, WarnFilteringSkippedNoChangeRequest)
+		return
+	}
+	if f.Err != nil {
+		// Test 1 failed or invalid server — leave as Untested with the
+		// existing generic warning.
+		return
+	}
+	switch {
+	case f.Test2Received && f.Test3Received:
+		v.Filtering = FilteringEndpointIndependent
+	case !f.Test2Received && f.Test3Received:
+		v.Filtering = FilteringAddressDependent
+	case !f.Test2Received && !f.Test3Received:
+		v.Filtering = FilteringAddressAndPortDependent
+	default:
+		// (T2=true, T3=false): inconsistent; keep Untested and the generic warning.
+		return
+	}
+	v.FilteringTestedAgainst = f.Server
+	v.Warnings = removeWarning(v.Warnings, WarnFilteringBehaviorNotTested)
+}
+
+// decideForecast computes the WebRTC forecast from a fully-populated Verdict.
+// Precedence (top-down, first match wins):
+//  1. CGNAT detected → unknown (v0.1 honesty rule preserved)
+//  2. Mapping ADM/APDM/Blocked → unlikely
+//  3. Mapping Unknown → unknown
+//  4. Mapping EIM with restrictive filtering (ADF/APDF) → possible
+//  5. Mapping EIM with EIF or untested filtering → likely
+func decideForecast(v Verdict) Forecast {
+	if v.CGNAT {
+		return Forecast{DirectP2P: "unknown", TURNRequired: false}
+	}
+	switch v.Type {
+	case Blocked:
+		return Forecast{DirectP2P: "unlikely", TURNRequired: true}
+	case AddressDependentMapping, AddressPortDependentMapping:
+		return Forecast{DirectP2P: "unlikely", TURNRequired: true}
+	case Unknown:
+		return Forecast{DirectP2P: "unknown", TURNRequired: false}
+	case EndpointIndependentMapping:
+		switch v.Filtering {
+		case FilteringAddressDependent, FilteringAddressAndPortDependent:
+			return Forecast{DirectP2P: "possible", TURNRequired: false}
+		default:
+			return Forecast{DirectP2P: "likely", TURNRequired: false}
+		}
+	default:
+		return Forecast{DirectP2P: "unknown", TURNRequired: false}
 	}
 }
 
@@ -156,4 +270,26 @@ func applyCGNAT(v *Verdict) {
 		v.CGNAT = true
 		v.Warnings = append(v.Warnings, WarnCGNATDetected)
 	}
+}
+
+func replaceWarning(ws []string, old, new string) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		if w == old {
+			out = append(out, new)
+		} else {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func removeWarning(ws []string, target string) []string {
+	out := make([]string, 0, len(ws))
+	for _, w := range ws {
+		if w != target {
+			out = append(out, w)
+		}
+	}
+	return out
 }

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -204,7 +204,7 @@ func TestClassify(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Classify(tc.results)
+			got := Classify(tc.results, nil)
 
 			if got.Type != tc.wantType {
 				t.Errorf("Type = %v, want %v", got.Type, tc.wantType)
@@ -215,8 +215,8 @@ func TestClassify(t *testing.T) {
 			if got.CGNAT != tc.wantCGNAT {
 				t.Errorf("CGNAT = %v, want %v", got.CGNAT, tc.wantCGNAT)
 			}
-			if got.FilteringTested {
-				t.Errorf("FilteringTested = true, want false (invariant in v0.1)")
+			if got.Filtering != FilteringUntested {
+				t.Errorf("Filtering = %v, want FilteringUntested (no filtering result passed)", got.Filtering)
 			}
 			if got.Forecast.DirectP2P != tc.wantP2P {
 				t.Errorf("DirectP2P = %q, want %q", got.Forecast.DirectP2P, tc.wantP2P)
@@ -225,7 +225,7 @@ func TestClassify(t *testing.T) {
 				t.Errorf("TURNRequired = %v, want %v", got.Forecast.TURNRequired, tc.wantTURN)
 			}
 			if !hasWarning(got.Warnings, WarnFilteringBehaviorNotTested) {
-				t.Errorf("Warnings missing %q (always required in v0.1); got %v",
+				t.Errorf("Warnings missing %q (required when filtering not tested); got %v",
 					WarnFilteringBehaviorNotTested, got.Warnings)
 			}
 			for _, want := range tc.wantWarnings {
@@ -240,10 +240,10 @@ func TestClassify(t *testing.T) {
 // TestClassify_NilSafe: the brain of the tool must not panic on degenerate
 // inputs. Callers may hand us nil or zero-value results in error paths.
 func TestClassify_NilSafe(t *testing.T) {
-	_ = Classify(nil)
-	_ = Classify([]probe.Result{})
-	_ = Classify([]probe.Result{{}})         // zero-value result
-	_ = Classify([]probe.Result{{}, {}, {}}) // multiple zero-value
+	_ = Classify(nil, nil)
+	_ = Classify([]probe.Result{}, nil)
+	_ = Classify([]probe.Result{{}}, nil)         // zero-value result
+	_ = Classify([]probe.Result{{}, {}, {}}, nil) // multiple zero-value
 }
 
 // TestNATType_String covers every branch.
@@ -270,4 +270,160 @@ func hasWarning(ws []string, w string) bool {
 		}
 	}
 	return false
+}
+
+// TestFilteringBehavior_String covers every branch.
+func TestFilteringBehavior_String(t *testing.T) {
+	cases := map[FilteringBehavior]string{
+		FilteringUntested:                "untested",
+		FilteringEndpointIndependent:     "endpoint-independent",
+		FilteringAddressDependent:        "address-dependent",
+		FilteringAddressAndPortDependent: "address-and-port-dependent",
+		FilteringBehavior(999):           "untested",
+	}
+	for b, want := range cases {
+		if got := b.String(); got != want {
+			t.Errorf("FilteringBehavior(%d).String() = %q, want %q", b, got, want)
+		}
+	}
+}
+
+// TestClassify_FilteringMatrix covers FilteringResult → Verdict.Filtering and
+// the forecast updates for EIM mappings.
+func TestClassify_FilteringMatrix(t *testing.T) {
+	eimProbes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.example.org", Port: 3478},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			Other:  netip.MustParseAddrPort("198.51.100.1:3479"),
+		},
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+		},
+	}
+	target := probe.Server{Host: "stun.example.org", Port: 3478}
+
+	cases := []struct {
+		name           string
+		filtering      *probe.FilteringResult
+		wantBehavior   FilteringBehavior
+		wantP2P        string
+		wantTested     bool
+		wantWarnHas    string // warning that must be present
+		wantWarnAbsent string // warning that must NOT be present
+	}{
+		{
+			name:         "nil_filtering",
+			filtering:    nil,
+			wantBehavior: FilteringUntested,
+			wantP2P:      "likely",
+			wantWarnHas:  WarnFilteringBehaviorNotTested,
+		},
+		{
+			name:           "not_supported",
+			filtering:      &probe.FilteringResult{Server: target, Err: probe.ErrFilteringNotSupported},
+			wantBehavior:   FilteringUntested,
+			wantP2P:        "likely",
+			wantWarnHas:    WarnFilteringSkippedNoChangeRequest,
+			wantWarnAbsent: WarnFilteringBehaviorNotTested,
+		},
+		{
+			name:         "test1_failed",
+			filtering:    &probe.FilteringResult{Server: target, Err: probe.ErrTest1Failed},
+			wantBehavior: FilteringUntested,
+			wantP2P:      "likely",
+			wantWarnHas:  WarnFilteringBehaviorNotTested,
+		},
+		{
+			name: "endpoint_independent",
+			filtering: &probe.FilteringResult{
+				Server: target, Test2Received: true, Test3Received: true,
+			},
+			wantBehavior:   FilteringEndpointIndependent,
+			wantP2P:        "likely",
+			wantTested:     true,
+			wantWarnAbsent: WarnFilteringBehaviorNotTested,
+		},
+		{
+			name: "address_dependent",
+			filtering: &probe.FilteringResult{
+				Server: target, Test2Received: false, Test3Received: true,
+			},
+			wantBehavior:   FilteringAddressDependent,
+			wantP2P:        "possible",
+			wantTested:     true,
+			wantWarnAbsent: WarnFilteringBehaviorNotTested,
+		},
+		{
+			name: "address_and_port_dependent",
+			filtering: &probe.FilteringResult{
+				Server: target, Test2Received: false, Test3Received: false,
+			},
+			wantBehavior:   FilteringAddressAndPortDependent,
+			wantP2P:        "possible",
+			wantTested:     true,
+			wantWarnAbsent: WarnFilteringBehaviorNotTested,
+		},
+		{
+			name: "rfc_impossible_t2_true_t3_false",
+			filtering: &probe.FilteringResult{
+				Server: target, Test2Received: true, Test3Received: false,
+			},
+			wantBehavior: FilteringUntested,
+			wantP2P:      "likely",
+			wantWarnHas:  WarnFilteringBehaviorNotTested,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Classify(eimProbes, tc.filtering)
+			if got.Filtering != tc.wantBehavior {
+				t.Errorf("Filtering = %v, want %v", got.Filtering, tc.wantBehavior)
+			}
+			if got.Forecast.DirectP2P != tc.wantP2P {
+				t.Errorf("DirectP2P = %q, want %q", got.Forecast.DirectP2P, tc.wantP2P)
+			}
+			if tc.wantTested && got.FilteringTestedAgainst != target {
+				t.Errorf("FilteringTestedAgainst = %v, want %v", got.FilteringTestedAgainst, target)
+			}
+			if !tc.wantTested && got.FilteringTestedAgainst != (probe.Server{}) {
+				t.Errorf("FilteringTestedAgainst = %v, want zero", got.FilteringTestedAgainst)
+			}
+			if tc.wantWarnHas != "" && !hasWarning(got.Warnings, tc.wantWarnHas) {
+				t.Errorf("Warnings missing %q; got %v", tc.wantWarnHas, got.Warnings)
+			}
+			if tc.wantWarnAbsent != "" && hasWarning(got.Warnings, tc.wantWarnAbsent) {
+				t.Errorf("Warnings unexpectedly contains %q; got %v", tc.wantWarnAbsent, got.Warnings)
+			}
+		})
+	}
+}
+
+// TestDecideForecast_Precedence covers the forecast decision tree directly.
+func TestDecideForecast_Precedence(t *testing.T) {
+	cases := []struct {
+		name string
+		v    Verdict
+		want Forecast
+	}{
+		{"cgnat_overrides_all", Verdict{Type: EndpointIndependentMapping, CGNAT: true, Filtering: FilteringEndpointIndependent}, Forecast{DirectP2P: "unknown"}},
+		{"cgnat_on_blocked", Verdict{Type: Blocked, CGNAT: true}, Forecast{DirectP2P: "unknown"}},
+		{"blocked_no_cgnat", Verdict{Type: Blocked}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},
+		{"adm", Verdict{Type: AddressDependentMapping}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},
+		{"apdm", Verdict{Type: AddressPortDependentMapping}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},
+		{"unknown_mapping", Verdict{Type: Unknown}, Forecast{DirectP2P: "unknown"}},
+		{"eim_eif", Verdict{Type: EndpointIndependentMapping, Filtering: FilteringEndpointIndependent}, Forecast{DirectP2P: "likely"}},
+		{"eim_untested", Verdict{Type: EndpointIndependentMapping, Filtering: FilteringUntested}, Forecast{DirectP2P: "likely"}},
+		{"eim_adf", Verdict{Type: EndpointIndependentMapping, Filtering: FilteringAddressDependent}, Forecast{DirectP2P: "possible"}},
+		{"eim_apdf", Verdict{Type: EndpointIndependentMapping, Filtering: FilteringAddressAndPortDependent}, Forecast{DirectP2P: "possible"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decideForecast(tc.v)
+			if got != tc.want {
+				t.Errorf("decideForecast(%+v) = %+v, want %+v", tc.v, got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -94,7 +94,7 @@ func runWith(ctx context.Context, args []string, out, errOut io.Writer, prober p
 	if opts.json {
 		format = report.FormatJSON
 	}
-	if err := report.Render(out, verdict, results, filteringResult, format); err != nil {
+	if err := report.Render(out, verdict, results, format); err != nil {
 		_, _ = fmt.Fprintf(errOut, "render: %v\n", err)
 		return 2
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,13 +31,22 @@ var defaultServers = []probe.Server{
 	{Host: "stun.cloudflare.com", Port: 3478},
 }
 
+// FilteringFunc runs the RFC 5780 §4.4 filtering classification against a
+// single server. Default impl is probe.ProbeFiltering; tests inject stubs.
+type FilteringFunc func(ctx context.Context, s probe.Server, timeout time.Duration) probe.FilteringResult
+
+// filteringTimeoutCap bounds the wall-clock spent on the §4.4 sequence so
+// it doesn't extend mapping latency unbounded. ProbeFiltering subdivides
+// internally across Tests 1/2/3.
+const filteringTimeoutCap = 1500 * time.Millisecond
+
 // Run parses args, probes, classifies, renders, and returns an exit code.
 func Run(ctx context.Context, args []string, out, errOut io.Writer) int {
-	return runWith(ctx, args, out, errOut, probe.NewSTUN())
+	return runWith(ctx, args, out, errOut, probe.NewSTUN(), probe.ProbeFiltering)
 }
 
-// runWith is the testable core with an injectable Prober.
-func runWith(ctx context.Context, args []string, out, errOut io.Writer, prober probe.Prober) int {
+// runWith is the testable core with injectable Prober and FilteringFunc.
+func runWith(ctx context.Context, args []string, out, errOut io.Writer, prober probe.Prober, filterer FilteringFunc) int {
 	opts, err := parseFlags(args, errOut)
 	if err != nil {
 		// Usage already printed to errOut by flag.Parse.
@@ -62,13 +71,30 @@ func runWith(ctx context.Context, args []string, out, errOut io.Writer, prober p
 		}
 	}
 
-	verdict := classify.Classify(results)
+	// Capability detection: pick the first server whose mapping probe observed
+	// OTHER-ADDRESS, then run ProbeFiltering against it. Default servers
+	// (Google/Cloudflare) don't advertise OTHER-ADDRESS, so filtering is
+	// skipped and adds zero latency for default-server users.
+	var filteringResult *probe.FilteringResult
+	for _, r := range results {
+		if r.Err == nil && r.Other.IsValid() {
+			budget := opts.timeout
+			if budget > filteringTimeoutCap {
+				budget = filteringTimeoutCap
+			}
+			res := filterer(ctx, r.Server, budget)
+			filteringResult = &res
+			break
+		}
+	}
+
+	verdict := classify.Classify(results, filteringResult)
 
 	format := report.FormatHuman
 	if opts.json {
 		format = report.FormatJSON
 	}
-	if err := report.Render(out, verdict, results, format); err != nil {
+	if err := report.Render(out, verdict, results, filteringResult, format); err != nil {
 		_, _ = fmt.Fprintf(errOut, "render: %v\n", err)
 		return 2
 	}
@@ -165,7 +191,7 @@ func parseFlags(args []string, errOut io.Writer) (*options, error) {
 	var servers serverList
 
 	fs.Var(&servers, "server", "STUN server `host:port` (repeatable; overrides defaults)")
-	fs.DurationVar(&opts.timeout, "timeout", 5*time.Second, "total probe `duration`")
+	fs.DurationVar(&opts.timeout, "timeout", 5*time.Second, "total mapping-probe `duration` (filtering classification adds up to 1.5s when applicable)")
 	fs.BoolVar(&opts.json, "json", false, "emit JSON instead of human-readable report")
 	fs.BoolVar(&opts.verbose, "verbose", false, "log each STUN transaction to stderr")
 	fs.BoolVar(&opts.showVersion, "version", false, "print version and exit")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -56,10 +57,17 @@ func okProber() *fakeProber {
 	}}
 }
 
+// noFilterer returns a FilteringResult with ErrFilteringNotSupported. Used
+// when a test doesn't care about filtering (capability detection won't fire
+// for default servers anyway since the fakeProber doesn't populate Other).
+func noFilterer(_ context.Context, s probe.Server, _ time.Duration) probe.FilteringResult {
+	return probe.FilteringResult{Server: s, Err: probe.ErrFilteringNotSupported}
+}
+
 func run(t *testing.T, prober probe.Prober, args ...string) (int, string, string) {
 	t.Helper()
 	var out, errOut bytes.Buffer
-	code := runWith(context.Background(), args, &out, &errOut, prober)
+	code := runWith(context.Background(), args, &out, &errOut, prober, noFilterer)
 	return code, out.String(), errOut.String()
 }
 
@@ -242,6 +250,66 @@ func TestRun_TimeoutFires(t *testing.T) {
 	code, _, _ := run(t, fp, "--timeout", "50ms")
 	if code != 2 {
 		t.Errorf("code = %d, want 2 (all probes cancelled)", code)
+	}
+}
+
+func TestRun_FilteringPicksFirstCapableServer(t *testing.T) {
+	// Three servers; only #2 advertises OTHER-ADDRESS. Capability detection
+	// must invoke the filterer once with server #2 (not #0 or #1).
+	srv0 := probe.Server{Host: "stun.a.example", Port: 3478}
+	srv1 := probe.Server{Host: "stun.b.example", Port: 3478}
+	srv2 := probe.Server{Host: "stun.c.example", Port: 3478}
+	fp := &fakeProber{resultsByServer: map[string]probe.Result{
+		serverKey(srv0): {Mapped: netip.MustParseAddrPort("203.0.113.45:51820"), RTT: 10 * time.Millisecond},
+		serverKey(srv1): {Mapped: netip.MustParseAddrPort("203.0.113.45:51820"), RTT: 12 * time.Millisecond},
+		serverKey(srv2): {
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			Other:  netip.MustParseAddrPort("198.51.100.1:3479"),
+			RTT:    14 * time.Millisecond,
+		},
+	}}
+
+	var calledWith []probe.Server
+	var mu sync.Mutex
+	filterer := func(_ context.Context, s probe.Server, _ time.Duration) probe.FilteringResult {
+		mu.Lock()
+		calledWith = append(calledWith, s)
+		mu.Unlock()
+		return probe.FilteringResult{Server: s, Test2Received: true, Test3Received: true}
+	}
+
+	var out, errOut bytes.Buffer
+	code := runWith(context.Background(), []string{
+		"--server", serverKey(srv0),
+		"--server", serverKey(srv1),
+		"--server", serverKey(srv2),
+	}, &out, &errOut, fp, filterer)
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if len(calledWith) != 1 {
+		t.Fatalf("filterer called %d times, want 1", len(calledWith))
+	}
+	if calledWith[0] != srv2 {
+		t.Errorf("filterer called with %v, want %v", calledWith[0], srv2)
+	}
+}
+
+func TestRun_FilteringSkippedWhenNoCapableServer(t *testing.T) {
+	// Default fakeProber has no Other. Filterer must NOT be called.
+	fp := okProber()
+	var called int32
+	filterer := func(_ context.Context, _ probe.Server, _ time.Duration) probe.FilteringResult {
+		atomic.AddInt32(&called, 1)
+		return probe.FilteringResult{}
+	}
+	var out, errOut bytes.Buffer
+	code := runWith(context.Background(), nil, &out, &errOut, fp, filterer)
+	if code != 0 {
+		t.Errorf("code = %d, want 0", code)
+	}
+	if n := atomic.LoadInt32(&called); n != 0 {
+		t.Errorf("filterer called %d times, want 0 (no server advertised OTHER-ADDRESS)", n)
 	}
 }
 

--- a/internal/probe/filtering.go
+++ b/internal/probe/filtering.go
@@ -17,7 +17,11 @@ import (
 // filtering classification. Test1Other.IsValid() == false means the server
 // did not advertise OTHER-ADDRESS; in that case Test2Received and
 // Test3Received are both false and Err wraps ErrFilteringNotSupported.
+//
+// Server is the target of the §4.4 sequence (echoed from the ProbeFiltering
+// argument so consumers can attribute the result without re-threading state).
 type FilteringResult struct {
+	Server        Server
 	Test1Mapped   netip.AddrPort
 	Test1Other    netip.AddrPort
 	Test2Received bool
@@ -48,7 +52,7 @@ var errNoResponse = errors.New("no response within deadline")
 // per-test SetReadDeadline timers (timeout/2 each) drive the rest. Cancelling
 // ctx mid-call has no effect on in-flight reads.
 func ProbeFiltering(ctx context.Context, server Server, timeout time.Duration) FilteringResult {
-	res := FilteringResult{}
+	res := FilteringResult{Server: server}
 	if server.Host == "" || server.Port <= 0 || server.Port > 65535 {
 		res.Err = fmt.Errorf("invalid server %q:%d", server.Host, server.Port)
 		return res

--- a/internal/probe/probe.go
+++ b/internal/probe/probe.go
@@ -16,9 +16,15 @@ type Server struct {
 
 // Result captures the outcome of a single probe. On success, Mapped and RTT
 // are set and Err is nil. On failure, Err is non-nil and Mapped/RTT are zero.
+//
+// Other carries the OTHER-ADDRESS attribute (RFC 5780 §7.4) when the server
+// advertised one. Zero-value (Other.IsValid() == false) means the server's
+// response did not include OTHER-ADDRESS, so it does not support the §4.4
+// filtering classification sequence.
 type Result struct {
 	Server Server
 	Mapped netip.AddrPort
+	Other  netip.AddrPort
 	RTT    time.Duration
 	Err    error
 }

--- a/internal/probe/stun.go
+++ b/internal/probe/stun.go
@@ -105,5 +105,13 @@ func (stunProber) Probe(ctx context.Context, s Server) Result {
 		return res
 	}
 	res.Mapped = mapped
+
+	// OTHER-ADDRESS (RFC 5780 §7.4) is optional: silently skip when absent.
+	var oa stun.OtherAddress
+	if err := oa.GetFrom(resp); err == nil {
+		if otherIP, ok := netip.AddrFromSlice(oa.IP); ok {
+			res.Other = netip.AddrPortFrom(otherIP.Unmap(), uint16(oa.Port))
+		}
+	}
 	return res
 }

--- a/internal/probe/stun_test.go
+++ b/internal/probe/stun_test.go
@@ -272,6 +272,46 @@ func TestProbe_MissingMappedAddress(t *testing.T) {
 	}
 }
 
+func TestProbe_OtherAddressExtracted(t *testing.T) {
+	// Stand up a server that advertises OTHER-ADDRESS via stunserver.Options.Other.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	otherAddr := netip.MustParseAddrPort("198.51.100.1:3479")
+	srv := stunserver.New(stunserver.Options{Other: otherAddr})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = srv.Serve(ctx, conn) }()
+
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), time.Second)
+	defer probeCancel()
+	res := NewSTUN().Probe(probeCtx, Server{Host: "127.0.0.1", Port: port})
+	if res.Err != nil {
+		t.Fatalf("probe: %v", res.Err)
+	}
+	if res.Other != otherAddr {
+		t.Errorf("Other = %v, want %v", res.Other, otherAddr)
+	}
+}
+
+func TestProbe_OtherAddressAbsent(t *testing.T) {
+	// Phase-1 stunserver (no Other configured) → Result.Other stays zero.
+	f := newFakeSTUN(t, 0, behaviorNormal)
+	host, port := f.addr()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	res := NewSTUN().Probe(ctx, Server{Host: host, Port: port})
+	if res.Err != nil {
+		t.Fatalf("probe: %v", res.Err)
+	}
+	if res.Other.IsValid() {
+		t.Errorf("Other = %v, want zero (server didn't advertise)", res.Other)
+	}
+}
+
 func TestProbe_GarbledResponse(t *testing.T) {
 	f := newFakeSTUN(t, 0, behaviorGarbled)
 	host, port := f.addr()

--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -27,7 +27,9 @@ func natTypeHuman(v classify.Verdict) string {
 func warningText(id string) string {
 	switch id {
 	case classify.WarnFilteringBehaviorNotTested:
-		return "Filtering not tested (v0.1)."
+		return "Filtering not tested."
+	case classify.WarnFilteringSkippedNoChangeRequest:
+		return "Filtering skipped: server does not advertise OTHER-ADDRESS."
 	case classify.WarnCGNATDetected:
 		return "CGNAT detected (IP in 100.64.0.0/10)."
 	case classify.WarnADMOrStricter:
@@ -52,6 +54,14 @@ func renderHuman(w io.Writer, v classify.Verdict, probes []probe.Result) error {
 	fmt.Fprintf(&b, "NAT type: %s\n", natTypeHuman(v))
 	if v.PublicEndpoint.IsValid() {
 		fmt.Fprintf(&b, "Public endpoint: %s\n", v.PublicEndpoint)
+	}
+	if v.Filtering != classify.FilteringUntested {
+		if v.FilteringTestedAgainst.Host != "" {
+			fmt.Fprintf(&b, "Filtering: %s (tested against %s)\n",
+				v.Filtering, serverStr(v.FilteringTestedAgainst))
+		} else {
+			fmt.Fprintf(&b, "Filtering: %s\n", v.Filtering)
+		}
 	}
 
 	if len(probes) > 0 {

--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -23,13 +23,21 @@ type forecastJSON struct {
 	TURNRequired bool   `json:"turn_required"`
 }
 
+// filteringJSON is the v0.1.2-additive top-level "filtering" object.
+// tested_against is omitted when behavior == "untested".
+type filteringJSON struct {
+	Behavior      string `json:"behavior"`
+	TestedAgainst string `json:"tested_against,omitempty"`
+}
+
 type reportJSON struct {
-	NATType        string       `json:"nat_type"`
-	NATTypeLegacy  string       `json:"nat_type_legacy"`
-	PublicEndpoint string       `json:"public_endpoint"`
-	Probes         []probeJSON  `json:"probes"`
-	WebRTCForecast forecastJSON `json:"webrtc_forecast"`
-	Warnings       []string     `json:"warnings"`
+	NATType        string        `json:"nat_type"`
+	NATTypeLegacy  string        `json:"nat_type_legacy"`
+	PublicEndpoint string        `json:"public_endpoint"`
+	Probes         []probeJSON   `json:"probes"`
+	WebRTCForecast forecastJSON  `json:"webrtc_forecast"`
+	Warnings       []string      `json:"warnings"`
+	Filtering      filteringJSON `json:"filtering"`
 }
 
 // natTypeAbbrev is the stable JSON short name for a classify.NATType.
@@ -56,11 +64,15 @@ func renderJSON(w io.Writer, v classify.Verdict, probes []probe.Result) error {
 			DirectP2P:    v.Forecast.DirectP2P,
 			TURNRequired: v.Forecast.TURNRequired,
 		},
-		Warnings: v.Warnings,
-		Probes:   make([]probeJSON, len(probes)),
+		Warnings:  v.Warnings,
+		Probes:    make([]probeJSON, len(probes)),
+		Filtering: filteringJSON{Behavior: v.Filtering.String()},
 	}
 	if v.PublicEndpoint.IsValid() {
 		r.PublicEndpoint = v.PublicEndpoint.String()
+	}
+	if v.Filtering != classify.FilteringUntested && v.FilteringTestedAgainst.Host != "" {
+		r.Filtering.TestedAgainst = serverStr(v.FilteringTestedAgainst)
 	}
 	// Ensure arrays marshal as [] rather than null.
 	if r.Warnings == nil {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -25,9 +25,12 @@ const (
 	FormatJSON
 )
 
-// Render writes a Verdict + probe results to w in the requested format.
-// Writer and encoding errors are returned verbatim.
-func Render(w io.Writer, v classify.Verdict, probes []probe.Result, format Format) error {
+// Render writes a Verdict + probe results + optional filtering result to w
+// in the requested format. filtering may be nil; v.Filtering already encodes
+// the outcome via Classify, but callers (cli) can pass the original
+// FilteringResult through if needed for future renderers. Writer and
+// encoding errors are returned verbatim.
+func Render(w io.Writer, v classify.Verdict, probes []probe.Result, filtering *probe.FilteringResult, format Format) error {
 	switch format {
 	case FormatHuman:
 		return renderHuman(w, v, probes)

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -25,12 +25,11 @@ const (
 	FormatJSON
 )
 
-// Render writes a Verdict + probe results + optional filtering result to w
-// in the requested format. filtering may be nil; v.Filtering already encodes
-// the outcome via Classify, but callers (cli) can pass the original
-// FilteringResult through if needed for future renderers. Writer and
-// encoding errors are returned verbatim.
-func Render(w io.Writer, v classify.Verdict, probes []probe.Result, filtering *probe.FilteringResult, format Format) error {
+// Render writes a Verdict + probe results to w in the requested format.
+// Filtering data is consumed via v.Filtering and v.FilteringTestedAgainst
+// (already populated by classify.Classify). Writer and encoding errors are
+// returned verbatim.
+func Render(w io.Writer, v classify.Verdict, probes []probe.Result, format Format) error {
 	switch format {
 	case FormatHuman:
 		return renderHuman(w, v, probes)

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -18,7 +18,7 @@ import (
 //   - adm_strict: 2/2 probes disagree (symmetric NAT; TURN required)
 //   - blocked: 2/2 probes failed (no network to outbound STUN)
 
-func fixtureEIMCone() (classify.Verdict, []probe.Result) {
+func fixtureEIMCone() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
 	probes := []probe.Result{
 		{
 			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
@@ -31,10 +31,10 @@ func fixtureEIMCone() (classify.Verdict, []probe.Result) {
 			RTT:    31 * time.Millisecond,
 		},
 	}
-	return classify.Classify(probes), probes
+	return classify.Classify(probes, nil), probes, nil
 }
 
-func fixtureADMStrict() (classify.Verdict, []probe.Result) {
+func fixtureADMStrict() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
 	probes := []probe.Result{
 		{
 			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
@@ -47,10 +47,10 @@ func fixtureADMStrict() (classify.Verdict, []probe.Result) {
 			RTT:    31 * time.Millisecond,
 		},
 	}
-	return classify.Classify(probes), probes
+	return classify.Classify(probes, nil), probes, nil
 }
 
-func fixtureBlocked() (classify.Verdict, []probe.Result) {
+func fixtureBlocked() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
 	probes := []probe.Result{
 		{
 			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
@@ -61,7 +61,85 @@ func fixtureBlocked() (classify.Verdict, []probe.Result) {
 			Err:    errors.New("dial udp stun.cloudflare.com:3478: i/o timeout"),
 		},
 	}
-	return classify.Classify(probes), probes
+	return classify.Classify(probes, nil), probes, nil
+}
+
+// fixtureFilteringEIF: EIM mapping + endpoint-independent filtering.
+// Forecast: likely (no change vs untested).
+func fixtureFilteringEIF() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
+	probes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.example.org", Port: 3478},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			Other:  netip.MustParseAddrPort("198.51.100.1:3479"),
+			RTT:    18 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    24 * time.Millisecond,
+		},
+	}
+	f := &probe.FilteringResult{
+		Server:        probe.Server{Host: "stun.example.org", Port: 3478},
+		Test1Mapped:   netip.MustParseAddrPort("203.0.113.45:51820"),
+		Test1Other:    netip.MustParseAddrPort("198.51.100.1:3479"),
+		Test2Received: true,
+		Test3Received: true,
+	}
+	return classify.Classify(probes, f), probes, f
+}
+
+// fixtureFilteringADF: EIM mapping + address-dependent filtering.
+// Forecast: possible (Test 2 dropped, Test 3 received).
+func fixtureFilteringADF() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
+	probes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.example.org", Port: 3478},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			Other:  netip.MustParseAddrPort("198.51.100.1:3479"),
+			RTT:    18 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    24 * time.Millisecond,
+		},
+	}
+	f := &probe.FilteringResult{
+		Server:        probe.Server{Host: "stun.example.org", Port: 3478},
+		Test1Mapped:   netip.MustParseAddrPort("203.0.113.45:51820"),
+		Test1Other:    netip.MustParseAddrPort("198.51.100.1:3479"),
+		Test2Received: false,
+		Test3Received: true,
+	}
+	return classify.Classify(probes, f), probes, f
+}
+
+// fixtureFilteringAPDF: EIM mapping + address-and-port-dependent filtering.
+// Forecast: possible (both Test 2 and Test 3 dropped).
+func fixtureFilteringAPDF() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
+	probes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.example.org", Port: 3478},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			Other:  netip.MustParseAddrPort("198.51.100.1:3479"),
+			RTT:    18 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    24 * time.Millisecond,
+		},
+	}
+	f := &probe.FilteringResult{
+		Server:        probe.Server{Host: "stun.example.org", Port: 3478},
+		Test1Mapped:   netip.MustParseAddrPort("203.0.113.45:51820"),
+		Test1Other:    netip.MustParseAddrPort("198.51.100.1:3479"),
+		Test2Received: false,
+		Test3Received: false,
+	}
+	return classify.Classify(probes, f), probes, f
 }
 
 // compareGolden loads want from path and diff-compares against got. Set
@@ -87,10 +165,10 @@ func compareGolden(t *testing.T, path string, got []byte) {
 	}
 }
 
-func renderToBytes(t *testing.T, v classify.Verdict, probes []probe.Result, f Format) []byte {
+func renderToBytes(t *testing.T, v classify.Verdict, probes []probe.Result, filtering *probe.FilteringResult, f Format) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := Render(&buf, v, probes, f); err != nil {
+	if err := Render(&buf, v, probes, filtering, f); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	return buf.Bytes()
@@ -99,29 +177,32 @@ func renderToBytes(t *testing.T, v classify.Verdict, probes []probe.Result, f Fo
 func TestRender_Golden(t *testing.T) {
 	cases := []struct {
 		name    string
-		fixture func() (classify.Verdict, []probe.Result)
+		fixture func() (classify.Verdict, []probe.Result, *probe.FilteringResult)
 	}{
 		{"eim_cone", fixtureEIMCone},
 		{"adm_strict", fixtureADMStrict},
 		{"blocked", fixtureBlocked},
+		{"filtering_eif", fixtureFilteringEIF},
+		{"filtering_adf", fixtureFilteringADF},
+		{"filtering_apdf", fixtureFilteringAPDF},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			v, probes := tc.fixture()
+			v, probes, filtering := tc.fixture()
 
-			human := renderToBytes(t, v, probes, FormatHuman)
+			human := renderToBytes(t, v, probes, filtering, FormatHuman)
 			compareGolden(t, filepath.Join("testdata", "human", tc.name+".golden"), human)
 
-			j := renderToBytes(t, v, probes, FormatJSON)
+			j := renderToBytes(t, v, probes, filtering, FormatJSON)
 			compareGolden(t, filepath.Join("testdata", "json", tc.name+".golden"), j)
 		})
 	}
 }
 
 func TestRender_UnknownFormat(t *testing.T) {
-	v, probes := fixtureEIMCone()
+	v, probes, filtering := fixtureEIMCone()
 	var buf bytes.Buffer
-	if err := Render(&buf, v, probes, Format(99)); err == nil {
+	if err := Render(&buf, v, probes, filtering, Format(99)); err == nil {
 		t.Fatal("expected error on unknown format, got nil")
 	}
 }
@@ -137,7 +218,7 @@ func TestRender_WarningsAlwaysArray(t *testing.T) {
 		// Warnings intentionally nil.
 	}
 	var buf bytes.Buffer
-	if err := Render(&buf, v, nil, FormatJSON); err != nil {
+	if err := Render(&buf, v, nil, nil, FormatJSON); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	if !bytes.Contains(buf.Bytes(), []byte(`"warnings": []`)) {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -165,10 +165,10 @@ func compareGolden(t *testing.T, path string, got []byte) {
 	}
 }
 
-func renderToBytes(t *testing.T, v classify.Verdict, probes []probe.Result, filtering *probe.FilteringResult, f Format) []byte {
+func renderToBytes(t *testing.T, v classify.Verdict, probes []probe.Result, _ *probe.FilteringResult, f Format) []byte {
 	t.Helper()
 	var buf bytes.Buffer
-	if err := Render(&buf, v, probes, filtering, f); err != nil {
+	if err := Render(&buf, v, probes, f); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	return buf.Bytes()
@@ -200,9 +200,9 @@ func TestRender_Golden(t *testing.T) {
 }
 
 func TestRender_UnknownFormat(t *testing.T) {
-	v, probes, filtering := fixtureEIMCone()
+	v, probes, _ := fixtureEIMCone()
 	var buf bytes.Buffer
-	if err := Render(&buf, v, probes, filtering, Format(99)); err == nil {
+	if err := Render(&buf, v, probes, Format(99)); err == nil {
 		t.Fatal("expected error on unknown format, got nil")
 	}
 }
@@ -218,7 +218,7 @@ func TestRender_WarningsAlwaysArray(t *testing.T) {
 		// Warnings intentionally nil.
 	}
 	var buf bytes.Buffer
-	if err := Render(&buf, v, nil, nil, FormatJSON); err != nil {
+	if err := Render(&buf, v, nil, FormatJSON); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	if !bytes.Contains(buf.Bytes(), []byte(`"warnings": []`)) {

--- a/internal/report/testdata/human/adm_strict.golden
+++ b/internal/report/testdata/human/adm_strict.golden
@@ -6,5 +6,5 @@ Probes:
   stun.l.google.com:19302   rtt=24ms  mapped=203.0.113.45:51820
   stun.cloudflare.com:3478  rtt=31ms  mapped=203.0.113.45:51822
 
-Filtering not tested (v0.1).
+Filtering not tested.
 Classification is ADM or stricter.

--- a/internal/report/testdata/human/blocked.golden
+++ b/internal/report/testdata/human/blocked.golden
@@ -5,5 +5,5 @@ Probes:
   stun.l.google.com:19302   error=dial udp stun.l.google.com:19302: i/o timeout
   stun.cloudflare.com:3478  error=dial udp stun.cloudflare.com:3478: i/o timeout
 
-Filtering not tested (v0.1).
+Filtering not tested.
 All probes failed.

--- a/internal/report/testdata/human/eim_cone.golden
+++ b/internal/report/testdata/human/eim_cone.golden
@@ -6,4 +6,4 @@ Probes:
   stun.l.google.com:19302   rtt=24ms  mapped=203.0.113.45:51820
   stun.cloudflare.com:3478  rtt=31ms  mapped=203.0.113.45:51820
 
-Filtering not tested (v0.1).
+Filtering not tested.

--- a/internal/report/testdata/human/filtering_adf.golden
+++ b/internal/report/testdata/human/filtering_adf.golden
@@ -1,0 +1,8 @@
+Direct P2P: possible
+NAT type: Endpoint-Independent Mapping (cone)
+Public endpoint: 203.0.113.45:51820
+Filtering: address-dependent (tested against stun.example.org:3478)
+
+Probes:
+  stun.example.org:3478    rtt=18ms  mapped=203.0.113.45:51820
+  stun.l.google.com:19302  rtt=24ms  mapped=203.0.113.45:51820

--- a/internal/report/testdata/human/filtering_apdf.golden
+++ b/internal/report/testdata/human/filtering_apdf.golden
@@ -1,0 +1,8 @@
+Direct P2P: possible
+NAT type: Endpoint-Independent Mapping (cone)
+Public endpoint: 203.0.113.45:51820
+Filtering: address-and-port-dependent (tested against stun.example.org:3478)
+
+Probes:
+  stun.example.org:3478    rtt=18ms  mapped=203.0.113.45:51820
+  stun.l.google.com:19302  rtt=24ms  mapped=203.0.113.45:51820

--- a/internal/report/testdata/human/filtering_eif.golden
+++ b/internal/report/testdata/human/filtering_eif.golden
@@ -1,0 +1,8 @@
+Direct P2P: likely
+NAT type: Endpoint-Independent Mapping (cone)
+Public endpoint: 203.0.113.45:51820
+Filtering: endpoint-independent (tested against stun.example.org:3478)
+
+Probes:
+  stun.example.org:3478    rtt=18ms  mapped=203.0.113.45:51820
+  stun.l.google.com:19302  rtt=24ms  mapped=203.0.113.45:51820

--- a/internal/report/testdata/json/adm_strict.golden
+++ b/internal/report/testdata/json/adm_strict.golden
@@ -21,5 +21,8 @@
   "warnings": [
     "filtering_behavior_not_tested",
     "adm_or_stricter"
-  ]
+  ],
+  "filtering": {
+    "behavior": "untested"
+  }
 }

--- a/internal/report/testdata/json/blocked.golden
+++ b/internal/report/testdata/json/blocked.golden
@@ -19,5 +19,8 @@
   "warnings": [
     "filtering_behavior_not_tested",
     "all_probes_failed"
-  ]
+  ],
+  "filtering": {
+    "behavior": "untested"
+  }
 }

--- a/internal/report/testdata/json/filtering_adf.golden
+++ b/internal/report/testdata/json/filtering_adf.golden
@@ -4,24 +4,23 @@
   "public_endpoint": "203.0.113.45:51820",
   "probes": [
     {
-      "server": "stun.l.google.com:19302",
-      "rtt_ms": 24,
+      "server": "stun.example.org:3478",
+      "rtt_ms": 18,
       "mapped": "203.0.113.45:51820"
     },
     {
-      "server": "stun.cloudflare.com:3478",
-      "rtt_ms": 31,
+      "server": "stun.l.google.com:19302",
+      "rtt_ms": 24,
       "mapped": "203.0.113.45:51820"
     }
   ],
   "webrtc_forecast": {
-    "direct_p2p": "likely",
+    "direct_p2p": "possible",
     "turn_required": false
   },
-  "warnings": [
-    "filtering_behavior_not_tested"
-  ],
+  "warnings": [],
   "filtering": {
-    "behavior": "untested"
+    "behavior": "address-dependent",
+    "tested_against": "stun.example.org:3478"
   }
 }

--- a/internal/report/testdata/json/filtering_apdf.golden
+++ b/internal/report/testdata/json/filtering_apdf.golden
@@ -4,24 +4,23 @@
   "public_endpoint": "203.0.113.45:51820",
   "probes": [
     {
-      "server": "stun.l.google.com:19302",
-      "rtt_ms": 24,
+      "server": "stun.example.org:3478",
+      "rtt_ms": 18,
       "mapped": "203.0.113.45:51820"
     },
     {
-      "server": "stun.cloudflare.com:3478",
-      "rtt_ms": 31,
+      "server": "stun.l.google.com:19302",
+      "rtt_ms": 24,
       "mapped": "203.0.113.45:51820"
     }
   ],
   "webrtc_forecast": {
-    "direct_p2p": "likely",
+    "direct_p2p": "possible",
     "turn_required": false
   },
-  "warnings": [
-    "filtering_behavior_not_tested"
-  ],
+  "warnings": [],
   "filtering": {
-    "behavior": "untested"
+    "behavior": "address-and-port-dependent",
+    "tested_against": "stun.example.org:3478"
   }
 }

--- a/internal/report/testdata/json/filtering_eif.golden
+++ b/internal/report/testdata/json/filtering_eif.golden
@@ -4,13 +4,13 @@
   "public_endpoint": "203.0.113.45:51820",
   "probes": [
     {
-      "server": "stun.l.google.com:19302",
-      "rtt_ms": 24,
+      "server": "stun.example.org:3478",
+      "rtt_ms": 18,
       "mapped": "203.0.113.45:51820"
     },
     {
-      "server": "stun.cloudflare.com:3478",
-      "rtt_ms": 31,
+      "server": "stun.l.google.com:19302",
+      "rtt_ms": 24,
       "mapped": "203.0.113.45:51820"
     }
   ],
@@ -18,10 +18,9 @@
     "direct_p2p": "likely",
     "turn_required": false
   },
-  "warnings": [
-    "filtering_behavior_not_tested"
-  ],
+  "warnings": [],
   "filtering": {
-    "behavior": "untested"
+    "behavior": "endpoint-independent",
+    "tested_against": "stun.example.org:3478"
   }
 }


### PR DESCRIPTION
v0.1.2 phase 4 of 5. Filtering classification end-to-end.

`probe.Result` captures OTHER-ADDRESS during mapping probes; CLI runs `ProbeFiltering` only against capable servers — zero extra latency for default-server users (Google/Cloudflare don't advertise OTHER-ADDRESS). Verdict gains `Filtering FilteringBehavior` + `FilteringTestedAgainst probe.Server`. JSON adds top-level `"filtering"` object (always present; `tested_against` omitted when behavior=untested). Forecast for EIM × non-EIF combinations promoted to `"possible"` per design.md addendum. Forecast precedence factored into `decideForecast()` for v0.2/v0.3 extensibility. New warning `WarnFilteringSkippedNoChangeRequest`.

3 existing goldens updated additively (`"filtering": {"behavior": "untested"}`); 3 new (`filtering_eif`, `filtering_adf`, `filtering_apdf`).

## Verification

- `go vet`, `gofmt`, `go mod tidy -diff` clean
- `make test` (5 packages, race, 60s) green
- `make lint` 0 issues
- Coverage: classify 95.2%, cli 93.5%, probe 82.3%, report 90.4%, stunserver 91.4%