### PR TITLE
docs: add coturn config, setup guide, and v0.1.2 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+### Added
+
+- RFC 5780 §4.4 filtering classification when the target STUN server advertises `OTHER-ADDRESS`. natcheck runs the three-step CHANGE-REQUEST sequence and reports `endpoint-independent`, `address-dependent`, `address-and-port-dependent`, or `untested` filtering.
+- Top-level `"filtering"` object in `--json` output. Always present. `tested_against` field omitted when behavior is `untested`.
+- WebRTC forecast value `"possible"` now emitted for EIM mappings combined with restrictive (address-dependent or address-and-port-dependent) filtering.
+- `examples/coturn-natcheck.conf` + [`docs/coturn-setup.md`](docs/coturn-setup.md): minimum coturn config for filtering classification and a one-page setup guide.
+- `internal/stunserver` package (foundation for v0.1.4's `natcheck server` subcommand).
+
+### Changed
+
+- Default-server users (Google, Cloudflare) see no extra latency: filtering classification is skipped when no probe response advertises `OTHER-ADDRESS`. coturn / `natcheck server` users get filtering automatically.
+- `--timeout` flag help: now notes that filtering classification adds up to 1.5s when applicable.
+
+### JSON schema (additive — strict consumers update)
+
+- New top-level key: `"filtering": {"behavior": "...", "tested_against": "..."}`. Always present from this release onward; `tested_against` omitted when `behavior == "untested"`.
+- New warning value in `warnings[]`: `"filtering_skipped_no_change_request"` (server response did not include `OTHER-ADDRESS`, so the §4.4 sequence could not run).
+- The existing `"filtering_behavior_not_tested"` warning is still emitted when filtering classification was not attempted at all (no server in the probe set advertised `OTHER-ADDRESS`).
+
+Consumers doing strict equality on the entire JSON blob need to expect the new `filtering` key. Field-level consumers (e.g., `jq '.nat_type'`) are unaffected.
+
+### Known limitations (deferred)
+
+- Hairpinning detection — planned for v0.1.3.
+- `natcheck server` subcommand — planned for v0.1.4.
+- `WarnFilteringPartial` warning (one or more CHANGE-REQUEST probes failed in transit) — current `FilteringResult` shape can't distinguish "filter blocked" from "transport error", so the warning is not emitted. Will return when the probe-side gains the necessary granularity.
+
 ## [0.1.1] — 2026-04-19
 
 ### Fixed

--- a/docs/coturn-setup.md
+++ b/docs/coturn-setup.md
@@ -1,0 +1,46 @@
+# Running natcheck filtering classification against coturn
+
+natcheck implements RFC 5780 §4.4 filtering classification, but the public default servers (`stun.l.google.com`, `stun.cloudflare.com`) don't advertise the `OTHER-ADDRESS` attribute that §4.4 requires. To get a filtering verdict, point natcheck at a STUN server that supports CHANGE-REQUEST — coturn is the most common one.
+
+This page describes the minimum coturn config to test filtering. It's a **diagnostic-test posture**: no auth, no TLS, no rate limiting. Don't expose this configuration as a production STUN/TURN service.
+
+## What you need
+
+- A VM with a public IP (a $5 VPS works fine).
+- Two free UDP ports on that VM (defaults below: `3478` + `3479`).
+- coturn installed (`apt install coturn` on Debian/Ubuntu, `brew install coturn` on macOS).
+
+## The config
+
+Copy [`examples/coturn-natcheck.conf`](../examples/coturn-natcheck.conf) to your VM, then:
+
+1. Replace `YOUR_PUBLIC_IP` with the VM's external IP. On cloud VMs, the external IP is **not** the same as the interface IP shown by `ip addr` — use the IP your provider assigned (the one you'd `ssh` to). Getting this wrong is the most common cause of "filtering: untested" results.
+2. Start coturn pointing at the file:
+
+   ```sh
+   turnserver -c /path/to/coturn-natcheck.conf
+   ```
+
+3. Open UDP ports 3478 and 3479 in the VM's firewall / cloud security group.
+
+## Verifying with natcheck
+
+From any client network:
+
+```sh
+natcheck --server YOUR_PUBLIC_IP:3478 --json
+```
+
+The JSON output's top-level `"filtering"` object will show one of:
+
+- `"endpoint-independent"` — most permissive; direct P2P likely
+- `"address-dependent"` or `"address-and-port-dependent"` — restrictive; direct P2P possible (depends on ICE)
+- `"untested"` — coturn isn't responding from the alt port (config or firewall problem)
+
+Run from at least three different client networks (home, mobile hotspot, café Wi-Fi) to characterise your NAT against more than one source. After capture, tear down the VM — the diagnostic-posture config is not safe to leave running.
+
+## What's NOT covered
+
+- **CHANGE-IP** (RFC 5780 §7.2 bit A) requires coturn to listen on **two** IPs. The bundled config uses one IP and two ports, which only exercises bit B (CHANGE-PORT). For two-IP testing, add a second `listening-ip` line and ensure both addresses are reachable from the public internet.
+- **Production hardening** — auth (`lt-cred-mech`), TLS (`tls-listening-port`, `cert`/`pkey`), rate limiting, persistence, metrics. coturn's own README covers these. natcheck doesn't and shouldn't.
+- **Bundled `natcheck server` subcommand** — planned for v0.1.4 (see `docs/design.md` v0.2 addendum). Until then, coturn is the path.

--- a/examples/coturn-natcheck.conf
+++ b/examples/coturn-natcheck.conf
@@ -1,0 +1,30 @@
+# coturn config for natcheck filtering classification (RFC 5780 §4.4).
+#
+# Diagnostic-test posture: no auth, no TLS, no DTLS. NOT a production STUN
+# service. The unauthenticated, plaintext setup matches `natcheck server`'s
+# v0.2 design intent (see docs/design.md addendum). For production, refer to
+# coturn's own README and add auth, rate limiting, and transport security.
+#
+# Setup: see docs/coturn-setup.md.
+
+# Two ports on the same host so CHANGE-PORT (RFC 5780 §7.2 bit B) can be
+# honored. CHANGE-IP (bit A) requires a second listening-ip on a separate
+# interface; document there if you have one (typical $5 VPS does not).
+listening-port=3478
+alt-listening-port=3479
+
+# Bind to all IPv4/IPv6 interfaces. coturn picks the right one per request.
+listening-ip=0.0.0.0
+
+# Public IP for OTHER-ADDRESS / XOR-MAPPED-ADDRESS encoding. On cloud VMs this
+# is the *external* IP, not the network interface IP — the most common
+# stumbling block. Replace YOUR_PUBLIC_IP before starting coturn.
+external-ip=YOUR_PUBLIC_IP
+
+# Diagnostic posture: disable everything that would otherwise prompt setup.
+no-auth
+no-tls
+no-dtls
+
+# Stdout logging keeps the responder visible for `natcheck --verbose` cross-check.
+log-file=stdout


### PR DESCRIPTION
v0.1.2 phase 5 of 5 (docs portion). Tag + release deferred to a separate session for stock-taking.

`examples/coturn-natcheck.conf`: minimum coturn config for RFC 5780 §4.4 filtering classification (one IP / two ports; CHANGE-PORT only). Diagnostic-test posture (no auth/TLS/DTLS); explicitly not a production STUN service.

`docs/coturn-setup.md`: one-page setup walkthrough — install, configure, verify with `natcheck --server YOUR_PUBLIC_IP:3478 --json`. Calls out the external-IP-vs-interface-IP gotcha and what's NOT covered (CHANGE-IP needs two IPs; production hardening; bundled `natcheck server`).

`CHANGELOG.md`: v0.1.2 Unreleased section documenting the new top-level `filtering` JSON key, the `filtering_skipped_no_change_request` warning, the `"possible"` forecast value, default-server users seeing no extra latency, and the deferred items (hairpinning v0.1.3, `natcheck server` v0.1.4, `WarnFilteringPartial`).

## Verification

- `gofmt`, `make test`, `make lint` all green
- No code changes — docs/config only