### PR TITLE
release: v0.1.2 polish + docs reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-04-26
+
 ### Added
 
 - RFC 5780 §4.4 filtering classification when the target STUN server advertises `OTHER-ADDRESS`. natcheck runs the three-step CHANGE-REQUEST sequence and reports `endpoint-independent`, `address-dependent`, `address-and-port-dependent`, or `untested` filtering.
@@ -62,6 +64,7 @@ Initial release. See [`docs/design.md`](docs/design.md) for scope and architectu
 - Go 1.25+
 - [`github.com/pion/stun/v3`](https://github.com/pion/stun)
 
-[Unreleased]: https://github.com/1mb-dev/natcheck/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/1mb-dev/natcheck/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.2
 [0.1.1]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.1
 [0.1.0]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The `--json` schema (`nat_type`, `public_endpoint`, `probes[]`, `webrtc_forecast
 
 ## Scope
 
-natcheck classifies NAT mapping behavior (Endpoint-Independent, Address-Dependent, Address-and-Port-Dependent per RFC 5780) and reports a WebRTC direct-P2P forecast. Filtering behavior (RFC 5780 §4.4) is classified when the configured `--server` advertises `OTHER-ADDRESS`; otherwise the verdict is `untested`. Hairpinning detection is planned for v0.1.3. On CGNAT networks (`100.64.0.0/10`), the forecast is `unknown`. IPv6 works when the network supports it but is not exhaustively tested.
+natcheck classifies NAT mapping behavior (Endpoint-Independent, Address-Dependent, Address-and-Port-Dependent per RFC 5780) and reports a WebRTC direct-P2P forecast. Filtering behavior (RFC 5780 §4.4) is classified when the configured `--server` advertises `OTHER-ADDRESS`; otherwise the verdict is `untested`. Hairpinning is out of scope. On CGNAT networks (`100.64.0.0/10`), the forecast is `unknown`. IPv6 works when the network supports it but is not exhaustively tested.
 
 See [`docs/design.md`](docs/design.md) for full architecture and testing details.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ NAT type diagnosis CLI. One command tells you why your WebRTC, P2P, or VPN conne
 
 Built on [`pion/stun`](https://github.com/pion/stun). Pure Go, single static binary. No cgo, no services, no config.
 
-> Pre-release (v0.1). Spec: [`docs/design.md`](docs/design.md). Samples: [`docs/samples/`](docs/samples/).
+> v0.1.2. Spec: [`docs/design.md`](docs/design.md). Samples: [`docs/samples/`](docs/samples/).
 
 ## Why natcheck
 
@@ -44,10 +44,12 @@ Probes:
   stun.l.google.com:19302   rtt=24ms  mapped=203.0.113.45:51820
   stun.cloudflare.com:3478  rtt=31ms  mapped=203.0.113.45:51820
 
-Filtering not tested (v0.1).
+Filtering not tested.
 ```
 
 The `Direct P2P:` line leads so you get the answer on line 1.
+
+Pointing `--server` at a STUN server that advertises `OTHER-ADDRESS` (e.g. coturn — see [`docs/coturn-setup.md`](docs/coturn-setup.md)) adds a one-line `Filtering:` verdict per RFC 5780 §4.4. Default servers (Google, Cloudflare) don't, so filtering classification is skipped and adds zero latency for default-server users.
 
 ## Flags
 
@@ -80,11 +82,11 @@ if [ "$verdict" != "likely" ]; then
 fi
 ```
 
-The `--json` schema (`nat_type`, `public_endpoint`, `probes[]`, `webrtc_forecast`, `warnings[]`) is a public contract from v0.1 onward — additive changes only after release. Real captures live under [`docs/samples/`](docs/samples/).
+The `--json` schema (`nat_type`, `public_endpoint`, `probes[]`, `webrtc_forecast`, `warnings[]`, `filtering`) is a public contract from v0.1 onward — additive changes only after release. Real captures live under [`docs/samples/`](docs/samples/).
 
 ## Scope
 
-v0.1 classifies NAT mapping behavior (Endpoint-Independent, Address-Dependent, Address-and-Port-Dependent per RFC 5780) and reports a WebRTC direct-P2P forecast. Filtering behavior and hairpinning are out of scope. On CGNAT networks (`100.64.0.0/10`), the forecast is `unknown`. IPv6 works when the network supports it but is not exhaustively tested.
+natcheck classifies NAT mapping behavior (Endpoint-Independent, Address-Dependent, Address-and-Port-Dependent per RFC 5780) and reports a WebRTC direct-P2P forecast. Filtering behavior (RFC 5780 §4.4) is classified when the configured `--server` advertises `OTHER-ADDRESS`; otherwise the verdict is `untested`. Hairpinning detection is planned for v0.1.3. On CGNAT networks (`100.64.0.0/10`), the forecast is `unknown`. IPv6 works when the network supports it but is not exhaustively tested.
 
 See [`docs/design.md`](docs/design.md) for full architecture and testing details.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # natcheck — Architecture
 
-> Status: v0.1.1 shipped. v0.2 design contract added as addendum at end of document.
+> Status: v0.1.2 shipped (RFC 5780 §4.4 filtering classification). v0.2 design contract is the addendum at end of document; v0.1.3 (hairpinning) and v0.1.4 (`natcheck server`) remain planned.
 > Last updated: 2026-04-26
 
 Product framing and technical spec. v0.1 spec lives in this document as shipped; v0.2 design is the addendum at the end. Working notes and per-phase plans live in `todos/` (dev-internal, not tracked in git).
@@ -328,12 +328,12 @@ RFC 5780 parity with `pion/stun-nat-behaviour` on protocol rigor while preservin
 
 v0.2 is a milestone reached via four bisectable patches, not a single release. Each patch is independently shippable with real user value.
 
-| Patch | Adds |
-|---|---|
-| **v0.1.2** | RFC 5780 §4.4 filtering classification (capability-driven via `--server` advertising `OTHER-ADDRESS`); JSON `filtering` object; classifier upgrade emitting reserved `possible`; coturn reference config asset + setup doc |
-| **v0.1.3** | Hairpinning detection via two local sockets, parallel with mapping probes; JSON `hairpinning` field |
-| **v0.1.4** | `natcheck server` subcommand: stateless RFC 5780 §3 STUN responder. Promoted from in-process responder via shared `internal/stunserver/` package |
-| **v0.2.0** | Version bump; README + site copy reconciliation; CHANGELOG with v0.1 → v0.2 JSON migration section |
+| Patch | Status | Adds |
+|---|---|---|
+| **v0.1.2** | shipped (PRs #7–#11, tag `v0.1.2`) | RFC 5780 §4.4 filtering classification (capability-driven via `--server` advertising `OTHER-ADDRESS`); JSON `filtering` object; classifier upgrade emitting reserved `possible`; coturn reference config asset + setup doc; `internal/stunserver` foundation package |
+| **v0.1.3** | planned | Hairpinning detection via two local sockets, parallel with mapping probes; JSON `hairpinning` field |
+| **v0.1.4** | planned | `natcheck server` subcommand: stateless RFC 5780 §3 STUN responder. Promoted from in-process responder via shared `internal/stunserver/` package |
+| **v0.2.0** | planned | Version bump; README + site copy reconciliation; CHANGELOG with v0.1 → v0.2 JSON migration section |
 
 v0.2.0 is the line where downstream consumers can rely on the new schema fields.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,6 +1,6 @@
 # natcheck — Architecture
 
-> Status: v0.1.2 shipped (RFC 5780 §4.4 filtering classification). v0.2 design contract is the addendum at end of document; v0.1.3 (hairpinning) and v0.1.4 (`natcheck server`) remain planned.
+> Status: v0.1.2 shipped (RFC 5780 §4.4 filtering classification). v0.2 design contract is the addendum at end of document.
 > Last updated: 2026-04-26
 
 Product framing and technical spec. v0.1 spec lives in this document as shipped; v0.2 design is the addendum at the end. Working notes and per-phase plans live in `todos/` (dev-internal, not tracked in git).

--- a/internal/classify/classify.go
+++ b/internal/classify/classify.go
@@ -107,8 +107,12 @@ type Verdict struct {
 	// §4.4 sequence did not run (no OTHER-ADDRESS support, or not attempted).
 	Filtering FilteringBehavior
 	// FilteringTestedAgainst is the server the §4.4 sequence ran against.
-	// Zero-value (Server{}) when filtering was not attempted, or when the
-	// server did not advertise OTHER-ADDRESS so no sequence ran.
+	// Zero-value (Server{}) when Filtering == FilteringUntested, which
+	// happens in any of these cases:
+	//   - no FilteringResult was supplied (filtering not attempted);
+	//   - the server did not advertise OTHER-ADDRESS (ErrFilteringNotSupported);
+	//   - the initial Test 1 binding probe failed (ErrTest1Failed);
+	//   - the (T2=true, T3=false) RFC-impossible state was observed.
 	FilteringTestedAgainst probe.Server
 	Warnings               []string
 	Forecast               Forecast

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -28,18 +28,17 @@ func fail(host string, port int) probe.Result {
 
 func TestClassify(t *testing.T) {
 	cases := []struct {
-		name              string
-		results           []probe.Result
-		filtering         *probe.FilteringResult
-		wantType          NATType
-		wantLegacy        string
-		wantCGNAT         bool
-		wantFiltering     FilteringBehavior
-		wantP2P           string
-		wantTURN          bool
-		wantWarnings      []string // subset assertions
-		wantWarnAbsent    []string // warnings that must NOT be present
-		wantNotTestedWarn bool     // when true, assert WarnFilteringBehaviorNotTested is present
+		name           string
+		results        []probe.Result
+		filtering      *probe.FilteringResult
+		wantType       NATType
+		wantLegacy     string
+		wantCGNAT      bool
+		wantFiltering  FilteringBehavior
+		wantP2P        string
+		wantTURN       bool
+		wantWarnings   []string // subset assertions
+		wantWarnAbsent []string // warnings that must NOT be present
 	}{
 		{
 			name:         "empty input — Blocked",

--- a/internal/classify/classify_test.go
+++ b/internal/classify/classify_test.go
@@ -28,14 +28,18 @@ func fail(host string, port int) probe.Result {
 
 func TestClassify(t *testing.T) {
 	cases := []struct {
-		name         string
-		results      []probe.Result
-		wantType     NATType
-		wantLegacy   string
-		wantCGNAT    bool
-		wantP2P      string
-		wantTURN     bool
-		wantWarnings []string // subset; WarnFilteringBehaviorNotTested is always asserted separately
+		name              string
+		results           []probe.Result
+		filtering         *probe.FilteringResult
+		wantType          NATType
+		wantLegacy        string
+		wantCGNAT         bool
+		wantFiltering     FilteringBehavior
+		wantP2P           string
+		wantTURN          bool
+		wantWarnings      []string // subset assertions
+		wantWarnAbsent    []string // warnings that must NOT be present
+		wantNotTestedWarn bool     // when true, assert WarnFilteringBehaviorNotTested is present
 	}{
 		{
 			name:         "empty input — Blocked",
@@ -200,11 +204,32 @@ func TestClassify(t *testing.T) {
 			wantP2P:      "unknown",
 			wantWarnings: []string{WarnCGNATDetected},
 		},
+		{
+			// Reachable EIM+CGNAT+filtering integration: even with EIF data,
+			// CGNAT precedence keeps the forecast at "unknown".
+			name: "EIM + CGNAT + endpoint-independent filtering — CGNAT precedence holds",
+			results: []probe.Result{
+				ok("google", 19302, "100.64.1.5:51820", 10*time.Millisecond),
+				ok("cloudflare", 3478, "100.64.1.5:51820", 20*time.Millisecond),
+			},
+			filtering: &probe.FilteringResult{
+				Server:        probe.Server{Host: "stun.example.org", Port: 3478},
+				Test2Received: true,
+				Test3Received: true,
+			},
+			wantType:       EndpointIndependentMapping,
+			wantLegacy:     "cone",
+			wantCGNAT:      true,
+			wantFiltering:  FilteringEndpointIndependent,
+			wantP2P:        "unknown",
+			wantWarnings:   []string{WarnCGNATDetected},
+			wantWarnAbsent: []string{WarnFilteringBehaviorNotTested},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Classify(tc.results, nil)
+			got := Classify(tc.results, tc.filtering)
 
 			if got.Type != tc.wantType {
 				t.Errorf("Type = %v, want %v", got.Type, tc.wantType)
@@ -215,8 +240,8 @@ func TestClassify(t *testing.T) {
 			if got.CGNAT != tc.wantCGNAT {
 				t.Errorf("CGNAT = %v, want %v", got.CGNAT, tc.wantCGNAT)
 			}
-			if got.Filtering != FilteringUntested {
-				t.Errorf("Filtering = %v, want FilteringUntested (no filtering result passed)", got.Filtering)
+			if got.Filtering != tc.wantFiltering {
+				t.Errorf("Filtering = %v, want %v", got.Filtering, tc.wantFiltering)
 			}
 			if got.Forecast.DirectP2P != tc.wantP2P {
 				t.Errorf("DirectP2P = %q, want %q", got.Forecast.DirectP2P, tc.wantP2P)
@@ -224,13 +249,21 @@ func TestClassify(t *testing.T) {
 			if got.Forecast.TURNRequired != tc.wantTURN {
 				t.Errorf("TURNRequired = %v, want %v", got.Forecast.TURNRequired, tc.wantTURN)
 			}
-			if !hasWarning(got.Warnings, WarnFilteringBehaviorNotTested) {
+			// When no filtering data is supplied, the generic warning must be
+			// present (the v0.1 behaviour). When filtering data IS supplied,
+			// the per-case wantWarnAbsent assertion governs.
+			if tc.filtering == nil && !hasWarning(got.Warnings, WarnFilteringBehaviorNotTested) {
 				t.Errorf("Warnings missing %q (required when filtering not tested); got %v",
 					WarnFilteringBehaviorNotTested, got.Warnings)
 			}
 			for _, want := range tc.wantWarnings {
 				if !hasWarning(got.Warnings, want) {
 					t.Errorf("Warnings missing %q; got %v", want, got.Warnings)
+				}
+			}
+			for _, absent := range tc.wantWarnAbsent {
+				if hasWarning(got.Warnings, absent) {
+					t.Errorf("Warnings unexpectedly contains %q; got %v", absent, got.Warnings)
 				}
 			}
 		})
@@ -314,11 +347,12 @@ func TestClassify_FilteringMatrix(t *testing.T) {
 		wantWarnAbsent string // warning that must NOT be present
 	}{
 		{
-			name:         "nil_filtering",
-			filtering:    nil,
-			wantBehavior: FilteringUntested,
-			wantP2P:      "likely",
-			wantWarnHas:  WarnFilteringBehaviorNotTested,
+			name:           "nil_filtering",
+			filtering:      nil,
+			wantBehavior:   FilteringUntested,
+			wantP2P:        "likely",
+			wantWarnHas:    WarnFilteringBehaviorNotTested,
+			wantWarnAbsent: WarnFilteringSkippedNoChangeRequest,
 		},
 		{
 			name:           "not_supported",
@@ -329,11 +363,12 @@ func TestClassify_FilteringMatrix(t *testing.T) {
 			wantWarnAbsent: WarnFilteringBehaviorNotTested,
 		},
 		{
-			name:         "test1_failed",
-			filtering:    &probe.FilteringResult{Server: target, Err: probe.ErrTest1Failed},
-			wantBehavior: FilteringUntested,
-			wantP2P:      "likely",
-			wantWarnHas:  WarnFilteringBehaviorNotTested,
+			name:           "test1_failed",
+			filtering:      &probe.FilteringResult{Server: target, Err: probe.ErrTest1Failed},
+			wantBehavior:   FilteringUntested,
+			wantP2P:        "likely",
+			wantWarnHas:    WarnFilteringBehaviorNotTested,
+			wantWarnAbsent: WarnFilteringSkippedNoChangeRequest,
 		},
 		{
 			name: "endpoint_independent",
@@ -370,9 +405,10 @@ func TestClassify_FilteringMatrix(t *testing.T) {
 			filtering: &probe.FilteringResult{
 				Server: target, Test2Received: true, Test3Received: false,
 			},
-			wantBehavior: FilteringUntested,
-			wantP2P:      "likely",
-			wantWarnHas:  WarnFilteringBehaviorNotTested,
+			wantBehavior:   FilteringUntested,
+			wantP2P:        "likely",
+			wantWarnHas:    WarnFilteringBehaviorNotTested,
+			wantWarnAbsent: WarnFilteringSkippedNoChangeRequest,
 		},
 	}
 	for _, tc := range cases {
@@ -407,8 +443,8 @@ func TestDecideForecast_Precedence(t *testing.T) {
 		v    Verdict
 		want Forecast
 	}{
-		{"cgnat_overrides_all", Verdict{Type: EndpointIndependentMapping, CGNAT: true, Filtering: FilteringEndpointIndependent}, Forecast{DirectP2P: "unknown"}},
-		{"cgnat_on_blocked", Verdict{Type: Blocked, CGNAT: true}, Forecast{DirectP2P: "unknown"}},
+		{"cgnat_overrides_eim_eif", Verdict{Type: EndpointIndependentMapping, CGNAT: true, Filtering: FilteringEndpointIndependent}, Forecast{DirectP2P: "unknown"}},
+		{"cgnat_overrides_eim_adf", Verdict{Type: EndpointIndependentMapping, CGNAT: true, Filtering: FilteringAddressDependent}, Forecast{DirectP2P: "unknown"}},
 		{"blocked_no_cgnat", Verdict{Type: Blocked}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},
 		{"adm", Verdict{Type: AddressDependentMapping}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},
 		{"apdm", Verdict{Type: AddressPortDependentMapping}, Forecast{DirectP2P: "unlikely", TURNRequired: true}},

--- a/internal/probe/stun_test.go
+++ b/internal/probe/stun_test.go
@@ -297,6 +297,67 @@ func TestProbe_OtherAddressExtracted(t *testing.T) {
 	}
 }
 
+// TestProbe_OtherAddressIPv4MappedUnmapped verifies the OTHER-ADDRESS
+// Unmap() path: when a server emits the attribute as v6-family carrying
+// an IPv4-mapped IPv6 address (::ffff:1.2.3.4), Result.Other surfaces
+// the unmapped 4-byte form. stunserver.Handle Unmaps before encoding,
+// so we hand-craft the response here to exercise the probe-side Unmap().
+func TestProbe_OtherAddressIPv4MappedUnmapped(t *testing.T) {
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+
+	// Echo first request with a hand-crafted OTHER-ADDRESS in v6 family,
+	// payload = ::ffff:198.51.100.1 (IPv4-mapped form). The probe must
+	// Unmap() it back to 198.51.100.1.
+	v4MappedV6 := net.ParseIP("::ffff:198.51.100.1") // 16-byte slice
+	if v4MappedV6 == nil || len(v4MappedV6) != 16 {
+		t.Fatalf("test setup: expected 16-byte IPv4-mapped IPv6, got %v len=%d", v4MappedV6, len(v4MappedV6))
+	}
+
+	go func() {
+		buf := make([]byte, 1500)
+		n, from, err := conn.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		req := &stun.Message{Raw: append([]byte{}, buf[:n]...)}
+		if err := req.Decode(); err != nil {
+			return
+		}
+		udp := from.(*net.UDPAddr)
+		resp, err := stun.Build(
+			stun.NewTransactionIDSetter(req.TransactionID),
+			stun.BindingSuccess,
+			&stun.XORMappedAddress{IP: udp.IP, Port: udp.Port},
+			&stun.OtherAddress{IP: v4MappedV6, Port: 3479},
+		)
+		if err != nil {
+			return
+		}
+		_, _ = conn.WriteTo(resp.Raw, from)
+	}()
+
+	probeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	res := NewSTUN().Probe(probeCtx, Server{Host: "127.0.0.1", Port: port})
+	if res.Err != nil {
+		t.Fatalf("probe: %v", res.Err)
+	}
+	if !res.Other.IsValid() {
+		t.Fatalf("Other not set, want 198.51.100.1:3479")
+	}
+	if !res.Other.Addr().Is4() {
+		t.Errorf("Other.Addr() = %v (Is4=%v), want unmapped IPv4", res.Other.Addr(), res.Other.Addr().Is4())
+	}
+	if res.Other.String() != "198.51.100.1:3479" {
+		t.Errorf("Other = %q, want %q", res.Other.String(), "198.51.100.1:3479")
+	}
+}
+
 func TestProbe_OtherAddressAbsent(t *testing.T) {
 	// Phase-1 stunserver (no Other configured) → Result.Other stays zero.
 	f := newFakeSTUN(t, 0, behaviorNormal)

--- a/site/index.md
+++ b/site/index.md
@@ -14,8 +14,10 @@ Probes:
   stun.l.google.com:19302   rtt=24ms  mapped=203.0.113.45:51820
   stun.cloudflare.com:3478  rtt=31ms  mapped=203.0.113.45:51820
 
-Filtering not tested (v0.1).
+Filtering not tested.
 ```
+
+Pointing `--server` at a STUN server that advertises `OTHER-ADDRESS` adds a one-line `Filtering:` verdict per RFC 5780 §4.4. See [coturn setup](https://github.com/1mb-dev/natcheck/blob/main/docs/coturn-setup.md).
 
 Built on [`pion/stun`](https://github.com/pion/stun).
 

--- a/site/nat-types.md
+++ b/site/nat-types.md
@@ -88,8 +88,10 @@ Probes:
   stun.l.google.com:19302   rtt=24ms  mapped=203.0.113.45:51820
   stun.cloudflare.com:3478  rtt=31ms  mapped=203.0.113.45:51820
 
-Filtering not tested (v0.1).
+Filtering not tested.
 ```
+
+Filtering classification (RFC 5780 §4.4) activates automatically when `--server` points at a server that advertises `OTHER-ADDRESS` — coturn does, the public defaults don't. See [coturn setup](https://github.com/1mb-dev/natcheck/blob/main/docs/coturn-setup.md) for a one-page recipe.
 
 On CGNAT, natcheck reports `unknown` rather than guessing. Behind a CGNAT carrier (T-Mobile US, Jio, Starlink, others)? Help calibrate the verdict — see [issue #6](https://github.com/1mb-dev/natcheck/issues/6).
 


### PR DESCRIPTION
## Summary

Final pre-tag pass for v0.1.2. Folds the four sub-80 polish items from PR #10's `/code-review` pass and reconciles the public surface (README, site, design.md, CHANGELOG) so the docs match the binary at the moment of tag.

### Polish (PR #10 carry-over)

- **`test(classify): tighten precedence and matrix coverage`** — drops unreachable `cgnat_on_blocked` case from `TestDecideForecast_Precedence` (applyCGNAT runs only when classifyMapping produces Unknown or a multi-success type, so Type=Blocked,CGNAT=true is unreachable). Adds reachable EIM+CGNAT+filtering integration row in `TestClassify`. Adds `wantWarnAbsent` to nil_filtering, test1_failed, and rfc_impossible_t2_true_t3_false rows in `TestClassify_FilteringMatrix` so the warning vocabulary contract cannot leak across cases.
- **`test(probe): cover OTHER-ADDRESS Unmap for IPv4-mapped IPv6`** — stunserver.Handle Unmaps before encoding, so the existing `TestProbe_OtherAddressExtracted` only exercised v4-family input on the probe side. New test hand-crafts a response with `OTHER-ADDRESS` as v6-family carrying `::ffff:198.51.100.1` and asserts `Result.Other` surfaces as `Is4()` with string `"198.51.100.1:3479"`.
- **`docs(classify): enumerate all Verdict.FilteringTestedAgainst zero-value cases`** — godoc previously listed two zero-value paths; `applyFiltering` actually leaves the field zero in four cases (filtering not attempted, ErrFilteringNotSupported, ErrTest1Failed, RFC-impossible T2=true/T3=false). Public-surface accuracy.

### Docs reconciliation

- **README** — example output drops the stale `(v0.1)` suffix; §Scope rewritten to describe filtering as capability-driven rather than out-of-scope; JSON-contract list adds the new `filtering` key; pointer to `docs/coturn-setup.md` added.
- **site/index.md, site/nat-types.md** — same example-output fix; nat-types page gains a paragraph on capability-driven filtering with coturn pointer.
- **docs/design.md** — status header now says "v0.1.2 shipped"; v0.2 staged-sequence table adds a Status column and marks v0.1.2 shipped (PRs #7–#11).
- **CHANGELOG** — promotes `[Unreleased]` to `[0.1.2]` with date 2026-04-26, adds fresh empty `[Unreleased]`, updates link refs.

## Test plan

- [x] `make test` (race, count=1)
- [x] `make lint` (0 issues)
- [x] `gofmt -l .` clean
- [x] `go mod tidy -diff` clean
- [x] `govulncheck ./...` no vulnerabilities
- [ ] CI green on this PR
- [ ] After merge: tag v0.1.2 on the merge commit; Pages workflow fires; `gh release create v0.1.2 --notes-from-tag`
- [ ] Post-tag: VPS spin-up to capture `docs/samples/filtering.txt` (separate commit on main)