### PR TITLE
fix(coturn): v0.1.2.1 — enable rfc5780 and require external-ip pair form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. Format follows [Keep a 
 
 ## [Unreleased]
 
+## [0.1.2.1] — 2026-04-26
+
+### Fixed
+
+- `examples/coturn-natcheck.conf` now sets `rfc5780` and uses the `external-ip=public/private` pair form. coturn 4.x defaults RFC 5780 NAT behavior discovery to OFF; without `rfc5780`, coturn silently omits `OTHER-ADDRESS` from Binding responses and natcheck reports `filtering: untested`. A bare `external-ip=PUBLIC` (single value) triggers `STUN CHANGE_REQUEST not supported: only one IP address is provided` even on a single-NIC VM. Both bugs caused users following [`docs/coturn-setup.md`](docs/coturn-setup.md) on a fresh VPS to silently get the v0.1 behavior with no §4.4 classification, despite v0.1.2's headline feature being filtering classification against coturn.
+- `docs/coturn-setup.md` adds a verification step that has the user check coturn's stdout for the two specific warning lines that signal a misconfigured §4.4 path.
+
+No code or schema changes — `go install github.com/1mb-dev/natcheck/cmd/natcheck@v0.1.2` produces the same binary as `@v0.1.2.1`.
+
 ## [0.1.2] — 2026-04-26
 
 ### Added
@@ -64,7 +73,8 @@ Initial release. See [`docs/design.md`](docs/design.md) for scope and architectu
 - Go 1.25+
 - [`github.com/pion/stun/v3`](https://github.com/pion/stun)
 
-[Unreleased]: https://github.com/1mb-dev/natcheck/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/1mb-dev/natcheck/compare/v0.1.2.1...HEAD
+[0.1.2.1]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.2.1
 [0.1.2]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.2
 [0.1.1]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.1
 [0.1.0]: https://github.com/1mb-dev/natcheck/releases/tag/v0.1.0

--- a/docs/coturn-setup.md
+++ b/docs/coturn-setup.md
@@ -8,20 +8,30 @@ This page describes the minimum coturn config to test filtering. It's a **diagno
 
 - A VM with a public IP (a $5 VPS works fine).
 - Two free UDP ports on that VM (defaults below: `3478` + `3479`).
-- coturn installed (`apt install coturn` on Debian/Ubuntu, `brew install coturn` on macOS).
+- coturn 4.x installed (`apt install coturn` on Debian/Ubuntu, `brew install coturn` on macOS).
 
 ## The config
 
 Copy [`examples/coturn-natcheck.conf`](../examples/coturn-natcheck.conf) to your VM, then:
 
-1. Replace `YOUR_PUBLIC_IP` with the VM's external IP. On cloud VMs, the external IP is **not** the same as the interface IP shown by `ip addr` — use the IP your provider assigned (the one you'd `ssh` to). Getting this wrong is the most common cause of "filtering: untested" results.
-2. Start coturn pointing at the file:
+1. Replace `YOUR_PUBLIC_IP` with the VM's external IP — the address your cloud provider assigned (the one you `ssh` to).
+2. Replace `YOUR_PRIVATE_IP` with the VM's interface IP — the address `ip addr` shows on the primary NIC (e.g., `10.0.0.5`, `192.168.x.x`). On a single-NIC VM the two IPs differ; coturn needs both. A bare `external-ip=PUBLIC` (single value) triggers `STUN CHANGE_REQUEST not supported: only one IP address is provided`, and natcheck then reports `filtering: untested`. The bundled config keeps the `rfc5780` directive — coturn 4.x defaults RFC 5780 NAT behavior discovery to OFF.
+3. Start coturn pointing at the file:
 
    ```sh
    turnserver -c /path/to/coturn-natcheck.conf
    ```
 
-3. Open UDP ports 3478 and 3479 in the VM's firewall / cloud security group.
+4. Confirm coturn does NOT log either of these lines:
+
+   ```
+   WARNING: STUN CHANGE_REQUEST not supported: only one IP address is provided
+   INFO:    RFC5780 disabled! /NAT behavior discovery/
+   ```
+
+   If either appears, fix the config before continuing — natcheck will report `filtering: untested`.
+
+5. Open UDP ports 3478 and 3479 in the VM's firewall / cloud security group.
 
 ## Verifying with natcheck
 
@@ -35,7 +45,7 @@ The JSON output's top-level `"filtering"` object will show one of:
 
 - `"endpoint-independent"` — most permissive; direct P2P likely
 - `"address-dependent"` or `"address-and-port-dependent"` — restrictive; direct P2P possible (depends on ICE)
-- `"untested"` — coturn isn't responding from the alt port (config or firewall problem)
+- `"untested"` — coturn isn't advertising `OTHER-ADDRESS` (`rfc5780` not enabled, `external-ip` not in pair form, or coturn unreachable on the alt port — re-check step 4)
 
 Run from at least three different client networks (home, mobile hotspot, café Wi-Fi) to characterise your NAT against more than one source. After capture, tear down the VM — the diagnostic-posture config is not safe to leave running.
 

--- a/examples/coturn-natcheck.conf
+++ b/examples/coturn-natcheck.conf
@@ -16,10 +16,19 @@ alt-listening-port=3479
 # Bind to all IPv4/IPv6 interfaces. coturn picks the right one per request.
 listening-ip=0.0.0.0
 
-# Public IP for OTHER-ADDRESS / XOR-MAPPED-ADDRESS encoding. On cloud VMs this
-# is the *external* IP, not the network interface IP — the most common
-# stumbling block. Replace YOUR_PUBLIC_IP before starting coturn.
-external-ip=YOUR_PUBLIC_IP
+# Public/private IP pair. On a single-NIC cloud VM the *public* IP is the
+# external address (e.g., 203.0.113.45) and the *private* IP is the interface
+# address coturn binds to (e.g., 10.0.0.5 — what `ip addr` shows). Even on
+# the same VM, coturn requires the pair form to consider CHANGE-PORT
+# honorable; a bare `external-ip=PUBLIC` triggers
+# "STUN CHANGE_REQUEST not supported: only one IP address is provided".
+# Getting either IP wrong is the most common cause of "filtering: untested".
+external-ip=YOUR_PUBLIC_IP/YOUR_PRIVATE_IP
+
+# Enable RFC 5780 NAT behavior discovery. coturn 4.x defaults to OFF and
+# silently omits OTHER-ADDRESS without this directive — natcheck then
+# reports filtering as "untested" with WarnFilteringSkippedNoChangeRequest.
+rfc5780
 
 # Diagnostic posture: disable everything that would otherwise prompt setup.
 no-auth


### PR DESCRIPTION
## Summary

Patch release fixing two real-world bugs in the bundled coturn config that defeat v0.1.2's headline filtering classification feature.

### What broke

Discovered by trying to validate v0.1.2 end-to-end against a real coturn 4.10.0:

1. **Missing `rfc5780` directive.** coturn 4.x defaults RFC 5780 NAT behavior discovery to OFF. Without `rfc5780` in the conf, coturn logs `RFC5780 disabled! /NAT behavior discovery/` and silently omits `OTHER-ADDRESS` from Binding responses. natcheck capability detection (`internal/cli/cli.go:79–89`) misses, filtering reports `untested` with `WarnFilteringSkippedNoChangeRequest`.
2. **Bare `external-ip=PUBLIC` triggers** `STUN CHANGE_REQUEST not supported: only one IP address is provided`. coturn requires the pair form `external-ip=public/private` even on a single-NIC VM where the two IPs differ (public from cloud provider, private from `ip addr`).

Net effect: a user following `docs/coturn-setup.md` on a $5 VPS got coturn that didn't speak §4.4. Filtering classification never ran, despite v0.1.2 being **about** filtering classification.

### What changed

- **`examples/coturn-natcheck.conf`** — adds `rfc5780`; switches `external-ip=YOUR_PUBLIC_IP` → `external-ip=YOUR_PUBLIC_IP/YOUR_PRIVATE_IP`; expands the surrounding comments.
- **`docs/coturn-setup.md`** — documents both requirements; adds a verification step (step 4) that has the user grep coturn's stdout for the two specific WARNING/INFO lines that signal a misconfigured §4.4 path. The "untested" failure-mode bullet now points back to step 4.
- **`CHANGELOG.md`** — `[0.1.2.1]` Fixed entry, link refs.

### Scope

Conf-asset + docs only. No Go source change. `go install github.com/1mb-dev/natcheck/cmd/natcheck@v0.1.2` produces the same binary as `@v0.1.2.1`. The patch tag exists so the Homebrew formula and changelog can point at the corrected setup story.

## Test plan

- [x] `make test` (race, count=1) — green (no code change but sanity)
- [x] `make lint` — 0 issues
- [x] `gofmt -l .` — clean
- [x] coturn 4.10.0 with the new conf: `rfc5780` enabled, `STUN CHANGE_REQUEST not supported` warning gone — verified locally
- [ ] CI green on this PR
- [ ] Tag v0.1.2.1 on the merge commit; Pages workflow fires; `gh release create v0.1.2.1`
- [ ] Bump Homebrew tap formula to v0.1.2.1 (so `brew upgrade natcheck` lands the corrected `examples/` and `docs/` for users who installed via brew)