### PR TITLE
feat(report): stage nullable hairpinning field in JSON output

### DIFF
--- a/internal/report/json.go
+++ b/internal/report/json.go
@@ -38,6 +38,10 @@ type reportJSON struct {
 	WebRTCForecast forecastJSON  `json:"webrtc_forecast"`
 	Warnings       []string      `json:"warnings"`
 	Filtering      filteringJSON `json:"filtering"`
+	// Hairpinning is tri-state per docs/design.md:361: true / false / null.
+	// null distinguishes "didn't try" from "tested false". Always null until
+	// the probe path lands; see todos/releases/v0.1.4/phase-4-hairpinning.md.
+	Hairpinning *bool `json:"hairpinning"`
 }
 
 // natTypeAbbrev is the stable JSON short name for a classify.NATType.

--- a/internal/report/testdata/json/adm_strict.golden
+++ b/internal/report/testdata/json/adm_strict.golden
@@ -24,5 +24,6 @@
   ],
   "filtering": {
     "behavior": "untested"
-  }
+  },
+  "hairpinning": null
 }

--- a/internal/report/testdata/json/blocked.golden
+++ b/internal/report/testdata/json/blocked.golden
@@ -22,5 +22,6 @@
   ],
   "filtering": {
     "behavior": "untested"
-  }
+  },
+  "hairpinning": null
 }

--- a/internal/report/testdata/json/eim_cone.golden
+++ b/internal/report/testdata/json/eim_cone.golden
@@ -23,5 +23,6 @@
   ],
   "filtering": {
     "behavior": "untested"
-  }
+  },
+  "hairpinning": null
 }

--- a/internal/report/testdata/json/filtering_adf.golden
+++ b/internal/report/testdata/json/filtering_adf.golden
@@ -22,5 +22,6 @@
   "filtering": {
     "behavior": "address-dependent",
     "tested_against": "stun.example.org:3478"
-  }
+  },
+  "hairpinning": null
 }

--- a/internal/report/testdata/json/filtering_apdf.golden
+++ b/internal/report/testdata/json/filtering_apdf.golden
@@ -22,5 +22,6 @@
   "filtering": {
     "behavior": "address-and-port-dependent",
     "tested_against": "stun.example.org:3478"
-  }
+  },
+  "hairpinning": null
 }

--- a/internal/report/testdata/json/filtering_eif.golden
+++ b/internal/report/testdata/json/filtering_eif.golden
@@ -22,5 +22,6 @@
   "filtering": {
     "behavior": "endpoint-independent",
     "tested_against": "stun.example.org:3478"
-  }
+  },
+  "hairpinning": null
 }


### PR DESCRIPTION
Stages the nullable `"hairpinning"` field on `reportJSON` ahead of the v0.1.4 hairpinning probe path. Always null in this phase; goldens regenerated. Per `docs/design.md:361`, null distinguishes "not tested" from "tested false" — omitempty-off pointer is the tri-state idiom.

Verified: `go test -race ./...`, `golangci-lint run ./...`, `gofmt -l .` all clean.