### PR TITLE
fix(report): #19 — warningText cases + refined insufficient-probes wording

### DIFF
--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -43,7 +43,7 @@ func warningText(id string) string {
 		// the text must not imply the verdict itself is unknown.
 		return "Insufficient probes for one or more address families."
 	case classify.WarnMixedAddressFamilyProbes:
-		return "Verdict combines independent IPv4 and IPv6 classifications."
+		return "Mapping classification spans IPv4 and IPv6; each family observes its own NAT."
 	default:
 		return id
 	}

--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -37,7 +37,13 @@ func warningText(id string) string {
 	case classify.WarnAllProbesFailed:
 		return "All probes failed."
 	case classify.WarnInsufficientProbes:
-		return "Insufficient probes to determine mapping behavior."
+		// Fires whenever any per-family group has fewer than two probes.
+		// Under v0.1.3 combine semantics this can co-occur with a confident
+		// combined verdict (when the other family had two probes that agreed);
+		// the text must not imply the verdict itself is unknown.
+		return "Insufficient probes for one or more address families."
+	case classify.WarnMixedAddressFamilyProbes:
+		return "IPv4 and IPv6 probes both present; verdict reflects per-family agreement."
 	default:
 		return id
 	}

--- a/internal/report/human.go
+++ b/internal/report/human.go
@@ -43,7 +43,7 @@ func warningText(id string) string {
 		// the text must not imply the verdict itself is unknown.
 		return "Insufficient probes for one or more address families."
 	case classify.WarnMixedAddressFamilyProbes:
-		return "IPv4 and IPv6 probes both present; verdict reflects per-family agreement."
+		return "Verdict combines independent IPv4 and IPv6 classifications."
 	default:
 		return id
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -116,6 +116,52 @@ func fixtureFilteringADF() (classify.Verdict, []probe.Result, *probe.FilteringRe
 	return classify.Classify(probes, f), probes, f
 }
 
+// fixtureInsufficientProbes: a single successful probe. Combined verdict is
+// Unknown but the warning text must signal "partial information," not
+// "verdict impossible" — under v0.1.3 combine semantics, the warning fires
+// whenever any per-family group has fewer than two probes, which can include
+// cases where the other family produced a confident verdict.
+func fixtureInsufficientProbes() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
+	probes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    24 * time.Millisecond,
+		},
+	}
+	return classify.Classify(probes, nil), probes, nil
+}
+
+// fixtureMixedV4V6Disagree: IPv4 group agrees on EIM, IPv6 group disagrees
+// (looks like ADM). Combined verdict is Unknown. Exercises the render path
+// for WarnMixedAddressFamilyProbes — the v0.1.3 cross-address-family
+// classifier fix had no render regression guard before this fixture.
+func fixtureMixedV4V6Disagree() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
+	probes := []probe.Result{
+		{
+			Server: probe.Server{Host: "stun.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    24 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun.cloudflare.com", Port: 3478},
+			Mapped: netip.MustParseAddrPort("203.0.113.45:51820"),
+			RTT:    31 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun6.l.google.com", Port: 19302},
+			Mapped: netip.MustParseAddrPort("[2001:db8::1]:51820"),
+			RTT:    42 * time.Millisecond,
+		},
+		{
+			Server: probe.Server{Host: "stun6.cloudflare.com", Port: 3478},
+			Mapped: netip.MustParseAddrPort("[2001:db8::2]:51821"),
+			RTT:    47 * time.Millisecond,
+		},
+	}
+	return classify.Classify(probes, nil), probes, nil
+}
+
 // fixtureFilteringAPDF: EIM mapping + address-and-port-dependent filtering.
 // Forecast: possible (both Test 2 and Test 3 dropped).
 func fixtureFilteringAPDF() (classify.Verdict, []probe.Result, *probe.FilteringResult) {
@@ -185,6 +231,8 @@ func TestRender_Golden(t *testing.T) {
 		{"filtering_eif", fixtureFilteringEIF},
 		{"filtering_adf", fixtureFilteringADF},
 		{"filtering_apdf", fixtureFilteringAPDF},
+		{"mixed_v4v6_disagree", fixtureMixedV4V6Disagree},
+		{"insufficient_probes", fixtureInsufficientProbes},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/report/testdata/human/insufficient_probes.golden
+++ b/internal/report/testdata/human/insufficient_probes.golden
@@ -1,0 +1,9 @@
+Direct P2P: unknown
+NAT type: Unknown
+Public endpoint: 203.0.113.45:51820
+
+Probes:
+  stun.l.google.com:19302  rtt=24ms  mapped=203.0.113.45:51820
+
+Filtering not tested.
+Insufficient probes for one or more address families.

--- a/internal/report/testdata/human/mixed_v4v6_disagree.golden
+++ b/internal/report/testdata/human/mixed_v4v6_disagree.golden
@@ -1,0 +1,12 @@
+Direct P2P: unknown
+NAT type: Unknown
+Public endpoint: 203.0.113.45:51820
+
+Probes:
+  stun.l.google.com:19302    rtt=24ms  mapped=203.0.113.45:51820
+  stun.cloudflare.com:3478   rtt=31ms  mapped=203.0.113.45:51820
+  stun6.l.google.com:19302   rtt=42ms  mapped=[2001:db8::1]:51820
+  stun6.cloudflare.com:3478  rtt=47ms  mapped=[2001:db8::2]:51821
+
+Filtering not tested.
+IPv4 and IPv6 probes both present; verdict reflects per-family agreement.

--- a/internal/report/testdata/human/mixed_v4v6_disagree.golden
+++ b/internal/report/testdata/human/mixed_v4v6_disagree.golden
@@ -9,4 +9,4 @@ Probes:
   stun6.cloudflare.com:3478  rtt=47ms  mapped=[2001:db8::2]:51821
 
 Filtering not tested.
-IPv4 and IPv6 probes both present; verdict reflects per-family agreement.
+Verdict combines independent IPv4 and IPv6 classifications.

--- a/internal/report/testdata/human/mixed_v4v6_disagree.golden
+++ b/internal/report/testdata/human/mixed_v4v6_disagree.golden
@@ -9,4 +9,4 @@ Probes:
   stun6.cloudflare.com:3478  rtt=47ms  mapped=[2001:db8::2]:51821
 
 Filtering not tested.
-Verdict combines independent IPv4 and IPv6 classifications.
+Mapping classification spans IPv4 and IPv6; each family observes its own NAT.

--- a/internal/report/testdata/json/insufficient_probes.golden
+++ b/internal/report/testdata/json/insufficient_probes.golden
@@ -1,0 +1,24 @@
+{
+  "nat_type": "Unknown",
+  "nat_type_legacy": "",
+  "public_endpoint": "203.0.113.45:51820",
+  "probes": [
+    {
+      "server": "stun.l.google.com:19302",
+      "rtt_ms": 24,
+      "mapped": "203.0.113.45:51820"
+    }
+  ],
+  "webrtc_forecast": {
+    "direct_p2p": "unknown",
+    "turn_required": false
+  },
+  "warnings": [
+    "filtering_behavior_not_tested",
+    "insufficient_probes"
+  ],
+  "filtering": {
+    "behavior": "untested"
+  },
+  "hairpinning": null
+}

--- a/internal/report/testdata/json/mixed_v4v6_disagree.golden
+++ b/internal/report/testdata/json/mixed_v4v6_disagree.golden
@@ -1,0 +1,39 @@
+{
+  "nat_type": "Unknown",
+  "nat_type_legacy": "",
+  "public_endpoint": "203.0.113.45:51820",
+  "probes": [
+    {
+      "server": "stun.l.google.com:19302",
+      "rtt_ms": 24,
+      "mapped": "203.0.113.45:51820"
+    },
+    {
+      "server": "stun.cloudflare.com:3478",
+      "rtt_ms": 31,
+      "mapped": "203.0.113.45:51820"
+    },
+    {
+      "server": "stun6.l.google.com:19302",
+      "rtt_ms": 42,
+      "mapped": "[2001:db8::1]:51820"
+    },
+    {
+      "server": "stun6.cloudflare.com:3478",
+      "rtt_ms": 47,
+      "mapped": "[2001:db8::2]:51821"
+    }
+  ],
+  "webrtc_forecast": {
+    "direct_p2p": "unknown",
+    "turn_required": false
+  },
+  "warnings": [
+    "filtering_behavior_not_tested",
+    "mixed_address_family_probes"
+  ],
+  "filtering": {
+    "behavior": "untested"
+  },
+  "hairpinning": null
+}


### PR DESCRIPTION
Closes #19. Adds the missing `warningText` case for `WarnMixedAddressFamilyProbes` (was falling through to raw ID) and refines `WarnInsufficientProbes` text — under v0.1.3 combine semantics it can fire alongside a confident verdict, so the old "Insufficient probes to determine mapping behavior" implied too much. Two new golden fixtures pin both paths.

Verified: `go test -race ./...`, `golangci-lint run ./...`, `gofmt -l .` all clean.